### PR TITLE
Stage source INIUA into output dir before CO2 interpolation

### DIFF
--- a/ocp_tool/__main__.py
+++ b/ocp_tool/__main__.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from shutil import copy2
 
 from ocp_tool.config import load_config
 from ocp_tool.gaussian_grids import generate_gaussian_grid, read_fesom_grid_polygon
@@ -58,6 +59,10 @@ def run_ocp_tool(config):
 
         print("\nStep 7: Interpolating 3D CO2 concentrations...")
         icmgg_iniua_file = config.get_icmgg_iniua_file()
+        # Stage the source INIUA into the output dir (mirrors how the INIT
+        # file is copied in process_land_sea_mask); CO2 is then added in place.
+        icmgg_iniua_input = config.get_icmgg_iniua_input_file()
+        copy2(icmgg_iniua_input, icmgg_iniua_file)
         interpolate_co2_to_icmgg(
             str(config.co2_grib_file),
             str(icmgg_iniua_file),

--- a/ocp_tool/config.py
+++ b/ocp_tool/config.py
@@ -94,6 +94,10 @@ class OCPConfig:
         """Get path to output ICMGG INIT file."""
         return self.output_paths.openifs_modified / f'ICMGG{self.atmosphere.experiment_name}INIT_{self.ocean.grid_name}'
     
+    def get_icmgg_iniua_input_file(self) -> Path:
+        """Get path to input ICMGG INIUA file."""
+        return self.input_paths.openifs_default / f'ICMGG{self.atmosphere.experiment_name}INIUA'
+
     def get_icmgg_iniua_file(self) -> Path:
         """Get path to output ICMGG INIUA file."""
         return self.output_paths.openifs_modified / f'ICMGG{self.atmosphere.experiment_name}INIUA'

--- a/run_ocp_tool.py
+++ b/run_ocp_tool.py
@@ -14,6 +14,7 @@ import sys
 import time
 from os import makedirs
 from pathlib import Path
+from shutil import copy2
 
 from ocp_tool.config import load_config, OCPConfig
 from ocp_tool.gaussian_grids import generate_gaussian_grid, read_fesom_grid_polygon
@@ -108,6 +109,10 @@ def run_ocp_tool(config: OCPConfig) -> None:
         # Step 7: Interpolate 3D CO2 to INIUA file
         print("\nStep 7: Interpolating 3D CO2 concentrations...")
         icmgg_iniua_file = config.get_icmgg_iniua_file()
+        # Stage the source INIUA into the output dir (mirrors how the INIT
+        # file is copied in process_land_sea_mask); CO2 is then added in place.
+        icmgg_iniua_input = config.get_icmgg_iniua_input_file()
+        copy2(icmgg_iniua_input, icmgg_iniua_file)
         interpolate_co2_to_icmgg(
             str(config.co2_grib_file),
             str(icmgg_iniua_file),


### PR DESCRIPTION
## Problem

Step 7 (3D CO2 interpolation) reads **and** writes the `ICMGG…INIUA` file at the *output* path (`output/<exp>/openifs_input_modified/`), but nothing ever copies the source INIUA from the input directory into the output dir — unlike the INIT file, which is staged via `copy2()` in `process_land_sea_mask()` (`lsm.py`).

As a result:
- the CO2 read fails with `FileNotFoundError`,
- the error is caught and merely printed (`Error reading ICMGG file … No such file or directory`),
- the run still exits 0, and **no CO2 is written into the INIUA**.

This is silent — the pipeline reports success while the 3D CO2 field is missing from the regenerated INIUA.

## Fix

- Add `OCPConfig.get_icmgg_iniua_input_file()` returning the source INIUA path in `openifs_default`.
- Copy the source INIUA into the output path immediately before Step 7, in both entry points (`run_ocp_tool.py` and `ocp_tool/__main__.py`). CO2 is then added in place (the writer reads all original messages into memory before opening the output for writing, so in-place is safe).

## Verification

Re-ran `run_ocp_tool.py configs/TCO95_CORE3.yaml`:
- `Step 7 … Output GRIB file written … with 91 levels of CO2 data`
- `OCP-Tool processing complete!` (exit 0)
- Regenerated `ICMGGab45INIUA` now contains 91 CO2 messages (level 1 verified at the expected concentration).
