### PR TITLE
CI: replace pixi with pip for test + code-quality jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,38 @@ jobs:
   test-python:
     name: Test Python Code
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
-      
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system libraries
+        run: |
+          sudo apt-get update
+          # ecCodes C library so the `gribapi`/`eccodes` Python bindings import
+          sudo apt-get install -y libeccodes-dev
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Runtime deps needed to import the ocp_tool modules (no conda/pixi).
+          # pyfesom2 is not imported at module top level, so it is not required here.
+          pip install numpy scipy netcdf4 xarray matplotlib cartopy pandas pyyaml eccodes
+
       - name: Check Python scripts syntax
         run: |
-          pixi run python -m py_compile run_ocp_tool.py
-          pixi run python -m py_compile ocp_tool/*.py
+          python -m py_compile run_ocp_tool.py
+          python -m py_compile ocp_tool/*.py
           echo "✓ All Python scripts have valid syntax"
-      
+
       - name: Test import of ocp_tool modules
         run: |
-          pixi run python -c "
+          python -c "
           from ocp_tool.config import load_config, OCPConfig
           from ocp_tool.gaussian_grids import generate_gaussian_grid
           from ocp_tool.lsm import process_land_sea_mask
@@ -40,30 +55,35 @@ jobs:
   code-quality:
     name: Code Quality Checks
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          environments: dev
-      
+          python-version: '3.11'
+
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 black isort
+
       - name: Run flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names
-          pixi run -e dev flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.git,__pycache__,build,dist,.pixi
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.git,__pycache__,build,dist,.pixi
           # Exit-zero treats all errors as warnings
-          pixi run -e dev flake8 . --count --exit-zero --max-complexity=15 --max-line-length=120 --statistics --exclude=.git,__pycache__,build,dist,.pixi
-      
+          flake8 . --count --exit-zero --max-complexity=15 --max-line-length=120 --statistics --exclude=.git,__pycache__,build,dist,.pixi
+
       - name: Check code formatting with black
         run: |
-          pixi run -e dev black --check --diff --exclude='(\.git|\.pixi)' . || echo "::warning::Code formatting issues found."
-      
+          black --check --diff --exclude='(\.git|\.pixi)' . || echo "::warning::Code formatting issues found."
+
       - name: Check import sorting with isort
         run: |
-          pixi run -e dev isort --check-only --diff --skip .pixi . || echo "::warning::Import sorting issues found."
+          isort --check-only --diff --skip .pixi . || echo "::warning::Import sorting issues found."
 
   documentation:
     name: Documentation Check


### PR DESCRIPTION
## Problem

The `Test Python Code` and `Code Quality Checks` jobs both fail at the `pixi install` / `pixi install -e dev` step — i.e. **environment resolution, before any project code runs**. This is preexisting on `master` (unrelated to any code change).

Evidence it's pixi's resolver and not the project deps:
- The `Build Documentation` job, which installs the *same package* via plain `pip install -e .`, **passes**.
- The non-pixi checks (Documentation Check, Security Scanning, Trivy) pass.

## Fix

Switch both jobs from `setup-pixi` to `actions/setup-python` + `pip`, mirroring the green docs job:

- **test-python**: install `libeccodes-dev` via apt (so the `gribapi`/`eccodes` Python bindings import — `gribapi` is the only conda-specific import, in `lsm.py`), then `pip install` the runtime deps actually imported by the tested modules. `pyfesom2` is **not** imported at module top level by any of the tested modules, so the heavy git dependency is omitted. Then run the existing syntax + import checks unchanged.
- **code-quality**: `pip install flake8 black isort` and run them directly (these need no project deps).

## Verification (local)

- All tracked Python compiles (`py_compile`) cleanly.
- The flake8 hard-fail gate `--select=E9,F63,F7,F82` reports **0** over the tracked tree (flake8 7.3.0).
- `ci.yml` parses as valid YAML.

The black/isort steps remain non-blocking (`|| echo ::warning::`), exactly as before.

Note: this is orthogonal to #48 (the CO2/INIUA staging fix) — that PR's red checks are this same preexisting pixi breakage and can be merged independently once this lands and its branch is updated.
