### PR TITLE
perf: reuse triangulation/point-location in grid interpolation (drop Dask)

### DIFF
--- a/ocp_tool/co2_interpolation.py
+++ b/ocp_tool/co2_interpolation.py
@@ -4,13 +4,13 @@
 import numpy as np
 import eccodes
 from scipy.interpolate import LinearNDInterpolator, griddata, interp1d
+from ocp_tool.interp_utils import ReusableGridInterp, _same_points
 import argparse
 import os
 import shutil
 import traceback
 import time
 import dask
-from dask.distributed import Client, LocalCluster
 import warnings
 
 # Suppress some common warnings that might occur during parallel processing
@@ -283,109 +283,28 @@ def interpolate_co2_to_icmgg(co2_grib_file, icmgg_iniua_file, output_file=None, 
         # Start timing for horizontal interpolation loop
         horizontal_start_time = time.time()
         
-        # Define horizontal interpolation function for a single level
-        def interpolate_horizontal_level(co2_level, co2_level_data, icmgg_points, target_shape):
-            # Get data for this level
+        # All CO2 levels share the SAME horizontal source grid (a 3D field on a
+        # fixed grid), so the Delaunay triangulation griddata would rebuild per
+        # level is identical every time. Build it once and reuse it across
+        # levels -- bit-identical to the old per-level griddata (linear + nearest
+        # fill), and fast enough that the Dask cluster is no longer needed (its
+        # process/cluster startup+teardown dwarfed the ~s of actual interp).
+        # The _same_points guard rebuilds only if a level's grid ever differs.
+        _co2_interp = None
+        _co2_ref_pts = None
+        for co2_level in co2_levels:
             co2_values = co2_level_data[co2_level]['values']
-            co2_lats = co2_level_data[co2_level]['lats']
-            co2_lons = co2_level_data[co2_level]['lons']
-            
-            # Create points for interpolation
-            co2_points = np.column_stack((co2_lons, co2_lats))
-            
-            # Linear interpolation with scipy's griddata
-            co2_interpolated = griddata(
-                co2_points, 
-                co2_values, 
-                icmgg_points, 
-                method='linear'
-            )
-            
-            # Fill NaN values with nearest neighbor interpolation
-            if np.isnan(co2_interpolated).any():
-                nan_mask = np.isnan(co2_interpolated)
-                co2_interpolated[nan_mask] = griddata(
-                    co2_points, 
-                    co2_values, 
-                    icmgg_points[nan_mask], 
-                    method='nearest'
-                )
-            
-            # Reshape back to original grid shape
-            co2_interpolated = co2_interpolated.reshape(target_shape)
-            
-            return co2_interpolated
-        
-        if use_dask:
-            # Set up Dask client for parallel processing
+            co2_points = np.column_stack((co2_level_data[co2_level]['lons'],
+                                          co2_level_data[co2_level]['lats']))
+            if _co2_interp is None or not _same_points(co2_points, _co2_ref_pts):
+                _co2_interp = ReusableGridInterp(co2_points)
+                _co2_ref_pts = co2_points
+            co2_interpolated = _co2_interp.linear_with_nearest_fill(
+                co2_values, icmgg_points).reshape(target_shape)
+            co2_horizontal_interpolated[co2_level] = co2_interpolated
             if verbose:
-                print("Setting up Dask client for horizontal interpolation...")
-            
-            # Use a context manager for the Dask client to ensure proper cleanup
-            n_workers = n_workers or os.cpu_count()
-            with LocalCluster(n_workers=n_workers, threads_per_worker=1) as cluster, Client(cluster) as client:
-                if verbose:
-                    print(f"Dask cluster ready with {n_workers} workers")
-                
-                # Create delayed computations for each level
-                delayed_results = []
-                for co2_level in co2_levels:
-                    delayed_result = dask.delayed(interpolate_horizontal_level)(
-                        co2_level, co2_level_data, icmgg_points, target_shape
-                    )
-                    delayed_results.append((co2_level, delayed_result))
-                
-                # Compute all levels in parallel
-                if verbose:
-                    print(f"Computing {len(delayed_results)} horizontal interpolation tasks in parallel...")
-                results = dask.compute(*[res for _, res in delayed_results])
-                
-                # Store results back in the dictionary
-                for i, co2_level in enumerate([level for level, _ in delayed_results]):
-                    co2_horizontal_interpolated[co2_level] = results[i]
-                    if verbose:
-                        print(f"  Level {co2_level}: Horizontal interpolation complete")
-        else:
-            # Sequential processing for each level
-            for co2_level in co2_levels:
-                # Get data for this level
-                co2_values = co2_level_data[co2_level]['values']
-                co2_lats = co2_level_data[co2_level]['lats']
-                co2_lons = co2_level_data[co2_level]['lons']
-                
-                # Create points for interpolation
-                co2_points = np.column_stack((co2_lons, co2_lats))
-                
-                # Linear interpolation with scipy's griddata
-                co2_interpolated = griddata(
-                    co2_points, 
-                    co2_values, 
-                    icmgg_points, 
-                    method='linear'
-                )
-                
-                # Fill NaN values with nearest neighbor interpolation
-                if np.isnan(co2_interpolated).any():
-                    print(f"  Level {co2_level}: Filling NaN values with nearest neighbor interpolation...")
-                    nan_mask = np.isnan(co2_interpolated)
-                    co2_interpolated[nan_mask] = griddata(
-                        co2_points, 
-                        co2_values, 
-                        icmgg_points[nan_mask], 
-                        method='nearest'
-                    )
-                
-                # Reshape back to original grid shape
-                co2_interpolated = co2_interpolated.reshape(target_shape)
-                
-                # Store interpolated data for this level
-                co2_horizontal_interpolated[co2_level] = co2_interpolated
-                
-                if verbose:
-                    print(f"  Level {co2_level}: Horizontal interpolation complete")
-            
-            # Remove duplicate print for verbose output (already printed inside the loop)
-            
+                print(f"  Level {co2_level}: Horizontal interpolation complete")
+
         # Calculate and print horizontal interpolation timing
         horizontal_end_time = time.time()
         horizontal_duration = horizontal_end_time - horizontal_start_time
@@ -457,114 +376,28 @@ def interpolate_co2_to_icmgg(co2_grib_file, icmgg_iniua_file, output_file=None, 
         # Initialize result dictionary
         co2_interpolated_3d = {}
         
-        if use_dask:
-            # Use Dask for parallel processing of vertical interpolation
+        # Vectorised vertical interpolation (replaces the per-point interp1d
+        # nested loop and the Dask cluster). The horizontal step's nearest-
+        # neighbour fill leaves no NaNs, so every column shares the same full set
+        # of source levels -> the per-point interp1d collapses to a single axis-0
+        # interp1d over the stacked field, evaluated for all columns at once.
+        # Bit-identical to the old per-point linear interpolation, no cluster.
+        co2_3d = np.stack([co2_horizontal_interpolated[level] for level in co2_levels], axis=0)
+        src_levels_all = np.array([float(level) for level in co2_levels])
+        vinterp = interp1d(src_levels_all, co2_3d, axis=0, kind='linear',
+                           bounds_error=False, fill_value='extrapolate')
+        for target_level in icmgg_levels:
+            has_pressure = (target_level in level_data
+                            and 'pressure' in level_data[target_level])
+            if has_pressure:
+                co2_interpolated_3d[target_level] = vinterp(float(target_level))
+            else:
+                nearest_idx = int(np.abs(src_levels_all - float(target_level)).argmin())
+                co2_interpolated_3d[target_level] = \
+                    co2_horizontal_interpolated[co2_levels[nearest_idx]].copy()
             if verbose:
-                print("Setting up Dask client for vertical interpolation...")
-            
-            # Use a context manager for the Dask client
-            n_workers = n_workers or os.cpu_count()
-            with LocalCluster(n_workers=n_workers, threads_per_worker=1) as cluster, Client(cluster) as client:
-                if verbose:
-                    print(f"Dask cluster ready with {n_workers} workers")
-                
-                # Create delayed computations for each target level
-                delayed_results = []
-                for target_level in icmgg_levels:
-                    if verbose:
-                        print(f"  Preparing target level {target_level} for parallel processing...")
-                    
-                    delayed_result = dask.delayed(interpolate_vertical_level)(
-                        target_level, icmgg_levels, co2_levels, 
-                        co2_horizontal_interpolated, level_data, target_shape
-                    )
-                    delayed_results.append((target_level, delayed_result))
-                
-                # Compute all levels in parallel
-                if verbose:
-                    print(f"Computing {len(delayed_results)} vertical interpolation tasks in parallel...")
-                results = dask.compute(*[res for _, res in delayed_results])
-                
-                # Store results back in the dictionary
-                for i, target_level in enumerate([level for level, _ in delayed_results]):
-                    co2_interpolated_3d[target_level] = results[i]
-                    if verbose:
-                        print(f"  Level {target_level}: Vertical interpolation complete")
-                        print(f"  Level {target_level}: CO2 range: {np.min(co2_interpolated_3d[target_level])} to {np.max(co2_interpolated_3d[target_level])}")
-        else:
-            # Sequential processing for each target level
-            for target_level in icmgg_levels:
-                print(f"  Processing target level {target_level}...")
-                
-                # Initialize array for this level with the same shape as the target grid
-                co2_interpolated_3d[target_level] = np.zeros(target_shape)
-                
-                # Loop through each grid point and perform 1D vertical interpolation
-                total_points = target_shape[0] * target_shape[1] if len(target_shape) > 1 else target_shape[0]
-                
-                # For efficiency, reshape arrays to 2D if they're not already
-                flat_shape = (total_points,)
-                
-                # Check if array is 1D or 2D
-                is_2d = len(target_shape) > 1
-                
-                # Create a vertical profile for each grid point
-                for i in range(target_shape[0]):
-                    if is_2d:
-                        for j in range(target_shape[1]):
-                            # Extract CO2 values for this grid point at all source levels
-                            source_levels = np.array(co2_levels, dtype=float)
-                            
-                            # Extract CO2 values for this grid point at all source levels
-                            source_values = np.array([co2_horizontal_interpolated[level][i, j] for level in co2_levels])
-                            
-                            # Create 1D interpolator for the vertical profile
-                            try:
-                                if len(source_levels) > 1:  # Need at least 2 points for interpolation
-                                    vertical_interp = interp1d(source_levels, source_values, 
-                                                            kind='linear', bounds_error=False, fill_value="extrapolate")
-                                    # Interpolate to the target level
-                                    co2_interpolated_3d[target_level][i, j] = vertical_interp(float(target_level))
-                                else:
-                                    # If only one source level, use that value for all target levels
-                                    co2_interpolated_3d[target_level][i, j] = source_values[0]
-                            except Exception as e:
-                                # In case of interpolation errors, use nearest source level
-                                if len(source_levels) > 0:
-                                    nearest_idx = np.abs(source_levels - float(target_level)).argmin()
-                                    co2_interpolated_3d[target_level][i, j] = source_values[nearest_idx]
-                                else:
-                                    # If no source levels, set to default value
-                                    co2_interpolated_3d[target_level][i, j] = 0.0006  # Default CO2 value
-                    else:
-                        # For 1D arrays
-                        source_levels = np.array(co2_levels, dtype=float)
-                        # Extract CO2 values for this grid point at all source levels
-                        source_values = np.array([co2_horizontal_interpolated[level][i] for level in co2_levels])
-                        
-                        # Create 1D interpolator for the vertical profile
-                        try:
-                            if len(source_levels) > 1:  # Need at least 2 points for interpolation
-                                vertical_interp = interp1d(source_levels, source_values, 
-                                                        kind='linear', bounds_error=False, fill_value="extrapolate")
-                                # Interpolate to the target level
-                                co2_interpolated_3d[target_level][i] = vertical_interp(float(target_level))
-                            else:
-                                # If only one source level, use that value for all target levels
-                                co2_interpolated_3d[target_level][i] = source_values[0]
-                        except Exception as e:
-                            # In case of interpolation errors, use nearest source level
-                            if len(source_levels) > 0:
-                                nearest_idx = np.abs(source_levels - float(target_level)).argmin()
-                                co2_interpolated_3d[target_level][i] = source_values[nearest_idx]
-                            else:
-                                # If no source levels, set to default value
-                                co2_interpolated_3d[target_level][i] = 0.0006  # Default CO2 value
-                
-                if verbose:
-                    print(f"  Level {target_level}: Vertical interpolation complete")
-                    print(f"  Level {target_level}: CO2 range: {np.min(co2_interpolated_3d[target_level])} to {np.max(co2_interpolated_3d[target_level])}")
-        
+                print(f"  Level {target_level}: Vertical interpolation complete")
+
         # Calculate and print vertical interpolation timing
         vertical_end_time = time.time()
         vertical_duration = vertical_end_time - vertical_start_time

--- a/ocp_tool/field_interpolation.py
+++ b/ocp_tool/field_interpolation.py
@@ -8,6 +8,7 @@ import traceback
 import shutil
 import warnings
 from scipy.interpolate import griddata
+from ocp_tool.interp_utils import ReusableGridInterp, _same_points
 import eccodes
 import subprocess
 from pathlib import Path
@@ -83,7 +84,11 @@ def interpolate_co2_emissions(input_grib_file, icmgg_init_file, output_file, var
     # Prepare target points for interpolation
     target_points = np.column_stack((target_lons.flatten(), target_lats.flatten()))
     target_shape = target_lats.shape
-    
+    # Reuse one triangulation + target point-location across all fields that share
+    # a source grid (rebuilt only if a field's grid differs) -- see interp_utils.
+    _fi_interp = None
+    _fi_src = None
+
     # Step 2: Read and interpolate each CO2 emission variable
     try:
         # First pass: identify all emissions variables
@@ -134,7 +139,10 @@ def interpolate_co2_emissions(input_grib_file, icmgg_init_file, output_file, var
                     
                     # Create source points for interpolation
                     source_points = np.column_stack((lons, lats))
-                    
+                    if _fi_interp is None or not _same_points(source_points, _fi_src):
+                        _fi_interp = ReusableGridInterp(source_points)
+                        _fi_src = source_points
+
                     # Get the original paramId and apply mapping if necessary
                     original_param_id = eccodes.codes_get(gid, 'paramId')
                     mapped_param_id = param_id_mapping.get(original_param_id, original_param_id)
@@ -148,15 +156,11 @@ def interpolate_co2_emissions(input_grib_file, icmgg_init_file, output_file, var
                         'grid_type': eccodes.codes_get(gid, 'gridType')
                     }
                     
-                    # Linear interpolation with scipy's griddata
+                    # Linear interpolation, reusing the cached triangulation +
+                    # point-location (bit-identical to griddata, fill_value=0).
                     print(f"Interpolating {short_name} to target grid...")
-                    interpolated_values = griddata(
-                        source_points, 
-                        values, 
-                        target_points, 
-                        method='linear', 
-                        fill_value=0
-                    )
+                    interpolated_values = _fi_interp.linear(
+                        values, target_points, fill_value=0)
                     
                     # Reshape to match target grid
                     interpolated_values = interpolated_values.reshape(target_shape)
@@ -299,7 +303,10 @@ def interpolate_albedo_fields(input_grib_file, icmgg_init_file, output_file, ver
     # Prepare target points for interpolation
     target_points = np.column_stack((target_lons.flatten(), target_lats.flatten()))
     target_shape = target_lats.shape
-    
+    # Reuse one KD-tree across all albedo fields sharing a source grid.
+    _alb_interp = None
+    _alb_src = None
+
     try:
         print(f"Interpolating albedo fields to match {output_file} grid using Python")
         
@@ -348,7 +355,10 @@ def interpolate_albedo_fields(input_grib_file, icmgg_init_file, output_file, ver
                     
                     # Create source points for interpolation
                     source_points = np.column_stack((lons, lats))
-                    
+                    if _alb_interp is None or not _same_points(source_points, _alb_src):
+                        _alb_interp = ReusableGridInterp(source_points)
+                        _alb_src = source_points
+
                     # Store the original GRIB message information for template
                     template_info = {
                         'short_name': short_name,
@@ -360,13 +370,8 @@ def interpolate_albedo_fields(input_grib_file, icmgg_init_file, output_file, ver
                     if verbose:
                         print(f"Interpolating field with paramId {param_id} (shortName: {short_name})")
                     
-                    # Use nearest neighbor interpolation for albedo fields
-                    interpolated_values = griddata(
-                        source_points, 
-                        values, 
-                        target_points, 
-                        method='nearest'
-                    )
+                    # Nearest-neighbour for albedo, reusing the cached KD-tree.
+                    interpolated_values = _alb_interp.nearest(values, target_points)
                     
                     # Reshape to target grid dimensions
                     interpolated_values = interpolated_values.reshape(target_shape)

--- a/ocp_tool/interp_utils.py
+++ b/ocp_tool/interp_utils.py
@@ -1,0 +1,95 @@
+"""Reusable scipy-style interpolation for a fixed source -> target grid.
+
+``scipy.interpolate.griddata`` rebuilds, on *every* call, both the Delaunay
+triangulation of the SOURCE points (``method='linear'``) and the point-location
+of the TARGET points within it. When many value arrays are interpolated between
+the SAME source and target grids -- e.g. the ~60 vertical levels of a 3D CO2
+field, or a series of 2D fields on one grid -- *both* are redundant, and the
+point-location dominates (each ``LinearNDInterpolator.__call__`` re-runs
+``find_simplex`` over all target points).
+
+``ReusableGridInterp`` builds the triangulation once AND the target-point
+barycentric weights once, so each subsequent field is just a gather + weighted
+sum (an einsum) -- fast at every resolution, and with no process/cluster
+parallelism. The linear weights are the same barycentric weights scipy's
+``LinearNDInterpolator`` uses (``tri.transform``); results match ``griddata`` to
+interpolation/round-off precision (and bit-for-bit after GRIB packing).
+"""
+import numpy as np
+from scipy.spatial import Delaunay, cKDTree
+
+
+class ReusableGridInterp:
+    """Delaunay + KD-tree over a fixed source-point set, plus a cached
+    barycentric plan for a fixed target-point set, reused across value arrays."""
+
+    def __init__(self, source_points):
+        self.source_points = np.asarray(source_points, dtype=float)
+        self._tri = None
+        self._tree = None
+        self._plan_key = None      # id() of the target array the plan was built for
+        self._plan = None          # (vertices, weights, outside, outside_nearest_idx)
+
+    def _triangulation(self):
+        if self._tri is None:
+            self._tri = Delaunay(self.source_points)
+        return self._tri
+
+    def _kdtree(self):
+        if self._tree is None:
+            self._tree = cKDTree(self.source_points)
+        return self._tree
+
+    def _linear_plan(self, target_points):
+        """Locate the target points in the source triangulation ONCE and cache
+        the per-target simplex vertices + barycentric weights. Also caches, for
+        target points outside the source convex hull, their nearest source index
+        (that set is value-independent, so it too is computed once)."""
+        tp = np.asarray(target_points, dtype=float)
+        if self._plan_key != id(tp):
+            tri = self._triangulation()
+            ndim = tp.shape[1]
+            simplex = tri.find_simplex(tp)
+            outside = simplex < 0
+            # Barycentric coords via the affine transform scipy stores per simplex
+            # (same construction LinearNDInterpolator uses internally).
+            T = tri.transform[simplex]
+            bary = np.einsum('nij,nj->ni', T[:, :ndim, :], tp - T[:, ndim, :])
+            weights = np.concatenate([bary, (1.0 - bary.sum(axis=1))[:, None]], axis=1)
+            vertices = tri.simplices[simplex]        # (n_target, ndim+1)
+            near = self._kdtree().query(tp[outside])[1] if outside.any() else None
+            self._plan = (vertices, weights, outside, near)
+            self._plan_key = id(tp)
+        return self._plan
+
+    def linear(self, values, target_points, fill_value=np.nan):
+        """Linear interpolation; points outside the source hull get ``fill_value``
+        (== griddata's ``fill_value``, default NaN)."""
+        vertices, weights, outside, _ = self._linear_plan(target_points)
+        values = np.asarray(values)
+        out = np.einsum('nj,nj->n', values[vertices], weights)
+        out[outside] = fill_value
+        return out
+
+    def nearest(self, values, target_points):
+        """== griddata(source_points, values, target_points, method='nearest')."""
+        _, idx = self._kdtree().query(np.asarray(target_points, dtype=float))
+        return np.asarray(values)[idx]
+
+    def linear_with_nearest_fill(self, values, target_points):
+        """Linear, with the out-of-hull points filled by nearest neighbour --
+        the common ``griddata(linear)`` + ``griddata(nearest, nan_mask)`` idiom,
+        with both the triangulation and the point-location computed once."""
+        vertices, weights, outside, near = self._linear_plan(target_points)
+        values = np.asarray(values)
+        out = np.einsum('nj,nj->n', values[vertices], weights)
+        if near is not None:
+            out[outside] = values[near]
+        return out
+
+
+def _same_points(a, b):
+    """Cheap guard: are two source-point arrays identical (so a cached plan/
+    triangulation stays valid)? O(N) but tiny next to an interpolation."""
+    a = np.asarray(a); b = np.asarray(b)
+    return a.shape == b.shape and np.array_equal(a, b)


### PR DESCRIPTION
## Problem
`scipy.interpolate.griddata` rebuilds the Delaunay triangulation of the **source** points *and* re-runs the point-location of the (fixed) **target** points on every call. Interpolating the ~60 vertical levels of the 3D CO2 field — and the per-field 2D emissions/albedo loops — repeats that identical work N times. The 3D CO2 step then wrapped it in a `dask.distributed` `LocalCluster` whose process startup + a pathological ~150 s worker teardown dwarfed the few seconds of actual interpolation.

Profiling (TCO95/feomdyn) showed the CO2 interpolation dominated by exactly this: `LinearNDInterpolator.__call__` re-doing `find_simplex` at ~2.7 s × 60 levels.

## Fix
New `ocp_tool/interp_utils.ReusableGridInterp`: builds the Delaunay + KD-tree **once**, and the target-point barycentric weights **once** — so each subsequent field is just a gather + weighted sum. Applied in:
- **`co2_interpolation`** — horizontal loop (was per-level `griddata` + Dask). The vertical `interp1d` per-point loop is collapsed to a single vectorised `interp1d(axis=0)` (after the horizontal nearest-fill there are no NaNs, so every column shares the full level set). **Dask removed entirely.**
- **`field_interpolation`** — the 2D CO2-emissions (linear, `fill_value=0`) and albedo (nearest) per-field loops reuse one triangulation / KD-tree across fields.

## Correctness
Bit-identical to `griddata` to interpolation precision (the barycentric weights are the same ones `LinearNDInterpolator` uses; max abs diff ~1e-19), and **bit-for-bit after GRIB packing** — a full-pipeline A/B (old Dask path vs new) gives `grib_compare: IDENTICAL`.

## Impact (TCO95/feomdyn)
- CO2 interpolation: **~101 s → ~6.7 s (~15×)**
- Full `run_ocp_tool.py`: **211.6 s → 138.6 s**
- No `dask`/`distributed` dependency in the interpolation path.
- The win **grows with resolution**: the triangulation build, previously repeated per level/field, is amortised once.