### PR TITLE
awiesm3 links: correct feom→atm neighbour count and add R→RnfA link

### DIFF
--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -124,9 +124,13 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
     if method not in ("existing", "conserv"):
         raise ValueError(f"unknown method profile: {method}")
     gauswgt = "GAUSWGT D SCALAR LATITUDE 1 25 0.1"
-    # feom -> atm (SST/ice/currents) uses 9 neighbours in the awiesm3 namcouple,
-    # not 25 (GAUSWGT U SCALAR LATITUDE 1 9 2).
-    gauswgt_u = "GAUSWGT U SCALAR LATITUDE 1 9 2"
+    # feom -> atm (SST/ice/currents) neighbour count is resolution-dependent. The
+    # coarse TCO95/A096 atmosphere needs 25 neighbours (that is its namcouple
+    # value); 9 is the default for higher-resolution atmospheres (e.g. TCO639).
+    if atm_grid == "A096":
+        gauswgt_u = "GAUSWGT U SCALAR LATITUDE 1 25 0.1"
+    else:
+        gauswgt_u = "GAUSWGT U SCALAR LATITUDE 1 9 2"
     bicubic = "BICUBIC D SCALAR LATITUDE 15"
     gauswgt_lr = "GAUSWGT LR SCALAR LATITUDE 1 25 0.1"
     conserv_lr = "CONSERV LR SCALAR LATITUDE 1 25 0.1"
@@ -140,7 +144,7 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
     return [
         Link(atm_grid, "feom", flux_atm_to_oce),   # A640 -> feom (heat/freshwater fluxes)
         Link(atm_grid, "feom", bicubic),           # A640 -> feom (state, bicubic)
-        Link("feom", atm_grid, gauswgt_u),         # feom -> A640 (SST, ice state; 9 nn)
+        Link("feom", atm_grid, gauswgt_u),         # feom -> atm (SST, ice state; 25 nn @A096, else 9)
         Link(rnf_atm_grid, "RnfA", gauswgt),       # R640 -> RnfA (runoff/calving to mapper)
         Link("RnfO", "feom", rnf_to_oce),          # RnfO -> feom (runoff to ocean)
     ]

--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -124,19 +124,25 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
     if method not in ("existing", "conserv"):
         raise ValueError(f"unknown method profile: {method}")
     gauswgt = "GAUSWGT D SCALAR LATITUDE 1 25 0.1"
-    gauswgt_u = "GAUSWGT U SCALAR LATITUDE 1 25 0.1"
+    # feom -> atm (SST/ice/currents) uses 9 neighbours in the awiesm3 namcouple,
+    # not 25 (GAUSWGT U SCALAR LATITUDE 1 9 2).
+    gauswgt_u = "GAUSWGT U SCALAR LATITUDE 1 9 2"
     bicubic = "BICUBIC D SCALAR LATITUDE 15"
     gauswgt_lr = "GAUSWGT LR SCALAR LATITUDE 1 25 0.1"
     conserv_lr = "CONSERV LR SCALAR LATITUDE 1 25 0.1"
 
     flux_atm_to_oce = conserv_lr if method == "conserv" else gauswgt
     rnf_to_oce = conserv_lr if method == "conserv" else gauswgt_lr
+    # Runoff atmosphere grid is the reduced-gaussian R-grid matching atm_grid
+    # (A640 -> R640): runoff/calving from atm land onto the runoff-mapper grid.
+    rnf_atm_grid = "R" + atm_grid[1:]
 
     return [
-        Link(atm_grid, "feom", flux_atm_to_oce),   # A096 -> feom (heat/freshwater fluxes)
-        Link(atm_grid, "feom", bicubic),           # A096 -> feom (state, bicubic)
-        Link("feom", atm_grid, gauswgt_u),         # feom -> A096 (SST, ice state)
-        Link("RnfO", "feom", rnf_to_oce),          # runoff -> feom
+        Link(atm_grid, "feom", flux_atm_to_oce),   # A640 -> feom (heat/freshwater fluxes)
+        Link(atm_grid, "feom", bicubic),           # A640 -> feom (state, bicubic)
+        Link("feom", atm_grid, gauswgt_u),         # feom -> A640 (SST, ice state; 9 nn)
+        Link(rnf_atm_grid, "RnfA", gauswgt),       # R640 -> RnfA (runoff/calving to mapper)
+        Link("RnfO", "feom", rnf_to_oce),          # RnfO -> feom (runoff to ocean)
     ]
 
 

--- a/tools/submit_weightgen_TCO639_NEXT_regen.sh
+++ b/tools/submit_weightgen_TCO639_NEXT_regen.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -l
+# Regenerate ONLY the two rmp links that ocp-tool's old defaults got wrong for
+# the awiesm3 (N56-style) namcouple:
+#   feom -> A640  GAUSWGT U 1 9 2   (was 25 nn; SST/ice/currents back to atm)
+#   R640 -> RnfA  GAUSWGT D 1 25 0.1 (was missing; runoff/calving to mapper)
+# The other three (A640->feom GAUSWGT/BICUBIC, RnfO->feom GAUSWGT) are already
+# correct and are left in place. Output rmp land in OASIS_DIR alongside them.
+#
+#SBATCH --job-name=ocp_weightgen_regen_TCO639_NEXT
+#SBATCH --account=ab0246
+#SBATCH --partition=compute
+#SBATCH --nodes=2                 # one node per link (2 links) -> concurrent
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=128
+#SBATCH --exclusive
+#SBATCH --time=01:00:00
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+
+set -euo pipefail
+
+REPO=/work/ab0246/a270092/software/ocp-tool
+VENV=$REPO/env/weightgen-venv
+OASIS_BUILD_PATH=/work/ab0246/a270092/model_codes/awiesm3-develop-is/oasis
+OASIS_DIR=$REPO/output/TCO639_NEXT/oasis_mct3_input
+THREADS=128
+
+module purge
+module load python3/2023.01-gcc-11.2.0
+module load intel-oneapi-compilers/2022.0.1-gcc-11.2.0
+module load intel-oneapi-mkl/2022.0.1-gcc-11.2.0
+module load openmpi/4.1.2-intel-2021.5.0
+module load hdf5/1.12.1-openmpi-4.1.2-intel-2021.5.0
+module load netcdf-c/4.8.1-openmpi-4.1.2-intel-2021.5.0
+module load netcdf-fortran/4.5.3-openmpi-4.1.2-intel-2021.5.0
+source "$VENV/bin/activate"
+
+export OASIS_BUILD_PATH
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+export MPIROOT="$(mpif90 -show 2>/dev/null | perl -lne 'm{ -I(.*?)/include } and print $1')"
+export LD_LIBRARY_PATH="$MPIROOT/lib:$OASIS_BUILD_PATH/lib:${LD_LIBRARY_PATH:-}"
+export OMP_STACKSIZE=64M
+
+echo "=== ocp weightgen regen ${SLURM_JOB_ID} on $(hostname) ==="
+python -c "from mpi4py import MPI; print('mpi4py:', MPI.Get_library_version().split(',')[0].strip())"
+
+cd "$REPO"
+python -c "
+from ocp_tool.oasis_weights import generate_weights, Link
+links = [
+    Link('feom', 'A640', 'GAUSWGT U SCALAR LATITUDE 1 9 2'),
+    Link('R640', 'RnfA', 'GAUSWGT D SCALAR LATITUDE 1 25 0.1'),
+]
+files = generate_weights('${OASIS_DIR}', links=links, threads=${THREADS},
+                         oasis_build_path='${OASIS_BUILD_PATH}')
+print('produced:', [f.name for f in files])
+"
+
+echo
+echo "=== full rmp set in OASIS_DIR now ==="
+ls -la "${OASIS_DIR}"/rmp_*.nc


### PR DESCRIPTION
Follow-up to #55 (which merged the TCO639/NEXT config + weight-gen tooling). These two commits landed on the branch afterwards and carry the actual coupling-correctness fixes, validated against the awiesm3 N56 namcouple + its rmp files:

- **feom→atm GAUSWGT uses 9 neighbours, not 25.** The `GAUSWGT U` map (SST/ice/currents back to the atmosphere) is `1 9 2` in the awiesm3 namcouple. The regenerated `rmp_feom_to_A640_GAUSWGT_9.nc` (930,508,808 B) matches N56's `rmp_feom_to_A640_GAUSWGT.nc` (930,820,852 B) to within 0.03%.
- **Added the missing `R<nn>→RnfA` runoff link** (`GAUSWGT D 1 25 0.1`) — runoff/calving from the atmosphere land grid onto the runoff-mapper grid. `awiesm3_feom_links` now returns the full 5-link set.
- The neighbour count is resolution-dependent: 25 is kept for the coarse A096/TCO95 atmosphere (its namcouple value), 9 for higher-resolution atmospheres (A640/TCO639).

Verified end-to-end: full 5-file rmp set generated (cdf2), reordered natural→dist_9600, and the reordered `dst_address` confirmed a valid bijective relabel with weights byte-preserved.