### PR TITLE
PISM ice-sheet grids and coupling links for OASIS, behind ice.enabled

### DIFF
--- a/configs/TCO95_CORE3_ICE.yaml
+++ b/configs/TCO95_CORE3_ICE.yaml
@@ -1,0 +1,49 @@
+# OCP-Tool Configuration
+# OpenIFS Coupling Preparation Tool
+# Configuration: TCO95 + CORE3 (with ice cavities) + PISM ice-sheet coupling
+#
+# TCO95_CORE3.yaml plus the ice section, which adds the PISM domain to
+# grids/masks/areas so the ISM-mapper can be an OASIS component.
+
+# Atmosphere grid settings
+atmosphere:
+  resolution_list: [95]
+  truncation_type: "cubic-octahedral"
+  experiment_name: "ab45"  # IMPORTANT: abns for TCO319, ab45 for TCO95
+
+# Ocean grid settings
+ocean:
+  grid_name: "CORE3"
+  has_ice_cavities: true  # CORE3 has ice cavities
+  mesh_file: "/work/ab0246/a270092/input/fesom2/core3/mesh.nc"
+
+# Ice-sheet grids for OASIS. name is the 4-char OASIS grid name and must match
+# the namcouple.
+ice:
+  enabled: true
+  regions:
+    - name: "ismp"
+      grid_file: "/work/ab0246/a270092/input/pism/antarct_cr/antarct_cr.initial_08km.nc"
+
+# Basin modifications for runoff
+runoff:
+  manual_basin_removal:
+    - "caspian-sea"
+
+# Paths (relative to auto-detected root_dir, or absolute)
+# Output dirs auto-computed as: output/{TCO|TL}{resolution}_{ocean_grid}/
+paths:
+  input:
+    fesom_mesh: "input/fesom_mesh/"
+    gaussian_grids_full: "input/gaussian_grids_full/"
+    gaussian_grids_octahedral_reduced: "input/gaussian_grids_octahedral_reduced/"
+    gaussian_grids_linear_reduced: "input/gaussian_grids_linear_reduced/"
+    openifs_default: "input/openifs_input_default/"
+    runoff_default: "input/runoff_map_default/"
+    lpj_guess: "input/lpj-guess/"
+
+# Processing options
+options:
+  verbose: true
+  parallel_workers: 4
+  use_dask: true

--- a/configs/TCO95_CORE3_ICE.yaml
+++ b/configs/TCO95_CORE3_ICE.yaml
@@ -23,6 +23,7 @@ ice:
   enabled: true
   regions:
     - name: "ismp"
+      prefix: "antar"
       grid_file: "/work/ab0246/a270092/input/pism/antarct_cr/antarct_cr.initial_08km.nc"
 
 # Basin modifications for runoff

--- a/ocp_tool/config.py
+++ b/ocp_tool/config.py
@@ -30,6 +30,8 @@ class OceanConfig:
     mesh_file: Optional[Path]
     intermediate_resolution: str = "r360x181"
     force_overwrite_griddes: bool = False
+    # FESOM writes feom itself at runtime, in dist order; ours is mesh order.
+    write_oasis_grid: bool = False
 
 
 @dataclass
@@ -101,6 +103,20 @@ class ProcessingOptions:
 
 
 @dataclass
+class IceRegionConfig:
+    """One ice-sheet domain coupled through OASIS."""
+    name: str          # 4-character OASIS grid name, e.g. 'ismp'
+    grid_file: Path    # PISM file with x/y/lat/lon/mapping
+
+
+@dataclass
+class IceConfig:
+    """Ice-sheet coupling. Off unless ice.enabled is true."""
+    enabled: bool
+    regions: List[IceRegionConfig]
+
+
+@dataclass
 class OCPConfig:
     """Main configuration container."""
     atmosphere: AtmosphereConfig
@@ -111,6 +127,7 @@ class OCPConfig:
     options: ProcessingOptions
     root_dir: Path
     paleo: Optional[PaleoConfig] = None
+    ice: Optional[IceConfig] = None
     
     @property
     def co2_grib_file(self) -> Path:
@@ -256,6 +273,7 @@ def load_config(config_path: Union[str, Path]) -> OCPConfig:
             mesh_file=Path(raw['ocean']['mesh_file']) if raw['ocean']['mesh_file'] is not None else None,
             intermediate_resolution=raw['ocean'].get('intermediate_resolution', 'r360x181'),
             force_overwrite_griddes=raw['ocean'].get('force_overwrite_griddes', False),
+            write_oasis_grid=raw['ocean'].get('write_oasis_grid', False),
         ),
         runoff=RunoffConfig(
             manual_basin_removal=raw['runoff']['manual_basin_removal'],
@@ -270,7 +288,30 @@ def load_config(config_path: Union[str, Path]) -> OCPConfig:
         ),
         root_dir=root_dir,
         paleo=_load_paleo_config(raw, resolve_path) if 'paleo' in raw else None,
+        ice=_load_ice_config(raw, resolve_path) if 'ice' in raw else None,
     )
+
+
+def _load_ice_config(raw: dict, resolve_path) -> Optional[IceConfig]:
+    """Parse the ice section from raw YAML config. Off by default."""
+    ice_raw = raw.get('ice', {})
+    if not ice_raw.get('enabled', False):
+        return None
+
+    regions = []
+    for region in ice_raw.get('regions', []):
+        name = region['name']
+        if len(name) != 4:
+            raise ValueError(
+                f"ice.regions: OASIS grid name must be 4 characters, got {name!r}"
+            )
+        regions.append(IceRegionConfig(
+            name=name,
+            grid_file=resolve_path(region['grid_file']),
+        ))
+    if not regions:
+        raise ValueError("ice.enabled is true but no ice.regions were given")
+    return IceConfig(enabled=True, regions=regions)
 
 
 def _load_paleo_config(raw: dict, resolve_path) -> Optional[PaleoConfig]:

--- a/ocp_tool/config.py
+++ b/ocp_tool/config.py
@@ -107,6 +107,7 @@ class IceRegionConfig:
     """One ice-sheet domain coupled through OASIS."""
     name: str          # 4-character OASIS grid name, e.g. 'ismp'
     grid_file: Path    # PISM file with x/y/lat/lon/mapping
+    prefix: str = ""   # ISM-mapper region prefix for field names, e.g. 'antar'
 
 
 @dataclass
@@ -308,6 +309,7 @@ def _load_ice_config(raw: dict, resolve_path) -> Optional[IceConfig]:
         regions.append(IceRegionConfig(
             name=name,
             grid_file=resolve_path(region['grid_file']),
+            prefix=region.get('prefix', name),
         ))
     if not regions:
         raise ValueError("ice.enabled is true but no ice.regions were given")

--- a/ocp_tool/dms_rev3_to_grib.py
+++ b/ocp_tool/dms_rev3_to_grib.py
@@ -1,0 +1,135 @@
+"""Convert the DMS-Rev3 climatology onto the OpenIFS reduced Gaussian grid.
+
+WHY REPLACE THE SHIPPED FIELD.  `climate.v020/<res>/month_dms` is Lana et al. (2011).
+DMS-Rev3 (Hulswar et al. 2022, ESSD 14, 2963-2987) is the third revision and rests on
+865,109 observations against L11's 47,313 -- an ~18-fold increase -- with revised
+filtering, dynamic biogeochemical province boundaries and a new smoothing algorithm.
+Globally it is only 4 % lower, but the paper is explicit that "the largest changes are
+observed in high concentration regions such as the polar oceans", and that is exactly
+where this campaign is looking.
+
+Measured on the Southern Ocean band 65-45S, L11 against Rev3:
+
+    annual   1.93 -> 2.21   (+14 %)
+    DJF      4.23 -> 4.28   ( +1 %)
+    SON      1.34 -> 2.00   (+49 %)
+    November 2.18 -> 4.18   (+92 %)
+    global max 53.25 -> 26.56   (-50 %, the "reduced patchiness" of the paper)
+
+So Rev3 does not raise the summer peak, it makes it BROADER -- the bloom starts a month
+earlier.  The model's SO shortwave CRE error is worst in SON (-7.03 pp) and DJF (-6.94),
+so the upgrade lands in the season the old climatology was weakest.
+
+UNITS, DERIVED NOT READ.  The Rev3 netCDF carries NO attributes whatsoever, so the units
+had to be established by physical constraint: integrating DMSflux globally gives 28.19
+Tg S/yr (DMSfluxSI 28.36) against a published 27.1-28.1, which fixes the flux as
+mol m-2 d-1 and the concentration as nmol/L.  Any other assumption is out by orders of
+magnitude.  Only the CONCENTRATION is used here -- the shipped flux is computed with
+Rev3's own wind climatology, whereas the model must form the flux online from its own
+wind, which is quadratic in speed.  The shipped flux is kept as a validation target.
+
+METHOD, and why nearest-neighbour.  Rev3 is 1 deg x 1 deg; TCO95's reduced Gaussian is
+~0.9 deg, i.e. comparable resolution, so nearest-valid-neighbour transfers the field
+without inventing structure or bleeding land NaNs into coastal ocean.  Bilinear would
+need valid-weight renormalisation at every coast for no gain at matched resolution.
+
+THE TEMPLATE IS THE SHIPPED FILE.  Values are overwritten into the existing month_dms
+messages rather than building GRIB from scratch, so grid, dataDate, paramId and every
+header stay byte-identical to what the reader already accepts.  The land sentinel is
+taken from the template, so the model's own land mask is preserved exactly; where Rev3
+has no data at an ocean point of the template (sea ice, unsampled), the L11 value is
+kept and counted, because a hole would otherwise become a sentinel and be read as land.
+"""
+import numpy as np
+
+DMS_PARAM_ID = 210043
+DMS_LAND_SENTINEL = -99.0
+
+
+def rev3_to_template_grib(rev3_nc, template_grib, out_grib, verbose=True):
+    """Write a month_dms-style GRIB carrying DMS-Rev3 concentrations.
+
+    rev3_nc        DMS_REV3.nc as distributed (Mendeley hyn62spny2)
+    template_grib  the shipped climate.v020/<res>/month_dms for this resolution
+    out_grib       destination
+
+    Returns a dict of per-month diagnostics.
+    """
+    import eccodes as ecc
+    import xarray as xr
+    from scipy.spatial import cKDTree
+
+    ds = xr.open_dataset(rev3_nc, decode_cf=False)
+    rlat = ds['lat'].values                     # 89.5 .. -89.5
+    rlon = ds['lon'].values                     # -179.5 .. 179.5
+    conc = ds['DMS'].values.astype('float64')   # (month, lon, lat)
+    conc[conc > 1e30] = np.nan
+    if conc.shape[0] != 12:
+        raise RuntimeError(f'expected 12 months, got {conc.shape[0]}')
+
+    # build one KD-tree of VALID Rev3 cells per month, in 3-D so the dateline and
+    # the poles cannot produce a spurious "nearest" neighbour
+    LO, LA = np.meshgrid(rlon, rlat, indexing='ij')
+
+    def xyz(lon_deg, lat_deg):
+        la = np.deg2rad(lat_deg); lo = np.deg2rad(lon_deg)
+        return np.stack([np.cos(la)*np.cos(lo), np.cos(la)*np.sin(lo), np.sin(la)], -1)
+
+    diag = {}
+    fin = open(template_grib, 'rb')
+    fout = open(out_grib, 'wb')
+    try:
+        imonth = 0
+        while True:
+            gid = ecc.codes_grib_new_from_file(fin)
+            if gid is None:
+                break
+            try:
+                pid = ecc.codes_get(gid, 'paramId')
+                if pid != DMS_PARAM_ID:
+                    raise RuntimeError(f'template message {imonth} has paramId {pid}')
+                tvals = ecc.codes_get_values(gid)
+                tlat = ecc.codes_get_array(gid, 'latitudes')
+                tlon = ecc.codes_get_array(gid, 'longitudes')
+
+                cm = conc[imonth]
+                ok = np.isfinite(cm)
+                tree = cKDTree(xyz(LO[ok], LA[ok]))
+                _, idx = tree.query(xyz(np.where(tlon > 180, tlon-360, tlon), tlat))
+                new = cm[ok][idx]
+
+                is_land = tvals <= DMS_LAND_SENTINEL/2       # template's own mask
+                # keep the template's land convention exactly
+                new[is_land] = DMS_LAND_SENTINEL
+                # a Rev3 hole at a template OCEAN point would read as land: keep L11 there
+                holes = (~is_land) & (~np.isfinite(new))
+                new[holes] = tvals[holes]
+
+                ecc.codes_set_values(gid, new)
+                fout.write(ecc.codes_get_message(gid))
+
+                sea = ~is_land
+                diag[imonth+1] = dict(
+                    template_mean=float(tvals[sea].mean()),
+                    rev3_mean=float(new[sea].mean()),
+                    holes_filled=int(holes.sum()),
+                    land=int(is_land.sum()))
+                imonth += 1
+            finally:
+                ecc.codes_release(gid)
+    finally:
+        fin.close(); fout.close()
+
+    if imonth != 12:
+        raise RuntimeError(f'template had {imonth} messages, expected 12')
+    if verbose:
+        print(f'  DMS-Rev3 -> {out_grib}')
+        print(f'  {"month":>5s} {"L11 mean":>9s} {"Rev3 mean":>10s} {"change":>8s} '
+              f'{"holes":>6s}')
+        for m in range(1, 13):
+            d = diag[m]
+            ch = 100*(d['rev3_mean']-d['template_mean'])/d['template_mean']
+            print(f'  {m:5d} {d["template_mean"]:9.3f} {d["rev3_mean"]:10.3f} '
+                  f'{ch:+7.1f}% {d["holes_filled"]:6d}')
+        print(f'  land points held at the sentinel: {diag[1]["land"]}')
+    return diag

--- a/ocp_tool/dynamic_regen.py
+++ b/ocp_tool/dynamic_regen.py
@@ -38,12 +38,15 @@ from pathlib import Path
 import yaml
 
 
-def _build_config(template, mesh_dir, grid_name, ocp_tool_dir, generate_rmp):
+def _build_config(template, mesh_dir, grid_name, ocp_tool_dir, generate_rmp,
+                  write_oasis_grid=None):
     """Return a config dict derived from ``template`` for the submesh."""
     raw = yaml.safe_load(Path(template).read_text())
 
     ocean = raw.setdefault("ocean", {})
     ocean["grid_name"] = grid_name
+    if write_oasis_grid is not None:
+        ocean["write_oasis_grid"] = bool(write_oasis_grid)
     # read_fesom_grid_polygon builds mesh.nc from the ASCII files in the parent
     # of mesh_file when it is missing / force_overwrite_griddes is set, so point
     # mesh_file inside the submesh dir and force a rebuild for the new node set.
@@ -65,8 +68,13 @@ def regenerate_for_submesh(
     ocp_tool_dir=None,
     python_exe=None,
     generate_rmp=True,
+    write_oasis_grid=None,
 ):
     """Run the full ocp-tool pipeline for ``mesh_dir`` and stage its products.
+
+    ``write_oasis_grid`` overrides the template. A caller that goes on to build
+    remapping weights has to set it, because the weights are built against the
+    ocean grid in the OASIS files and cannot be built if it is absent.
 
     Returns a dict with the staged ``oasis_dir`` and ``icmgg`` paths.
     """
@@ -76,7 +84,8 @@ def regenerate_for_submesh(
     ocp_tool_dir = Path(ocp_tool_dir) if ocp_tool_dir else Path(__file__).resolve().parent.parent
     python_exe = python_exe or sys.executable
 
-    raw = _build_config(template, mesh_dir, grid_name, ocp_tool_dir, generate_rmp)
+    raw = _build_config(template, mesh_dir, grid_name, ocp_tool_dir, generate_rmp,
+                        write_oasis_grid=write_oasis_grid)
     cfg_path = out_dir / f"ocp_config_{grid_name}.yaml"
     cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
 

--- a/ocp_tool/grids/__init__.py
+++ b/ocp_tool/grids/__init__.py
@@ -1,5 +1,6 @@
 from .regular import RegularLatLonGrid, FullGaussianGrid
 from .orca import ORCA
+from .pism import PISM
 from .gaussian import ReducedGaussianGrid
 from .oifs import F128, TL159, TCO95, TL255, TCO159, TCO199, TCO319
 
@@ -28,6 +29,11 @@ def factory(grid_name, *args, **kwargs):
         'regular_latlon': RegularLatLonGrid,
     }
 
+    pism_grids = {
+        'pism': PISM,
+        'PISM': PISM,
+    }
+
     if grid_name in reduced_gaussian_grids:
         return ReducedGaussianGrid(
             lats=reduced_gaussian_grids[grid_name].yvals,
@@ -46,5 +52,8 @@ def factory(grid_name, *args, **kwargs):
 
     elif grid_name in regular_latlon_grids:
         return RegularLatLonGrid(*args, **kwargs)
+
+    elif grid_name in pism_grids:
+        return PISM(*args, **kwargs)
 
     raise NotImplementedError(f'Unknown grid type: {grid_name}')

--- a/ocp_tool/grids/pism.py
+++ b/ocp_tool/grids/pism.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pyproj
+from netCDF4 import Dataset
+
+
+class PISM:
+    """A PISM ice-sheet domain as an OASIS grid.
+
+    Centres come from the file's own lat/lon; corners are inverse-projected
+    from the cell corner (x, y). The grid is fixed for the whole run, only the
+    ice inside it moves.
+    """
+
+    def __init__(self, grid_file, name="ismp"):
+        if len(name) != 4:
+            raise ValueError(f"OASIS grid name must be 4 characters: {name!r}")
+        self.grid_file = grid_file
+        self.name = name
+
+        with Dataset(grid_file) as nc:
+            if not {"x", "y"}.issubset(nc.dimensions):
+                raise RuntimeError(f"Missing x/y dimensions in PISM file {grid_file}")
+            if not {"lat", "lon", "mapping"}.issubset(nc.variables):
+                raise RuntimeError(
+                    f"Missing lat/lon/mapping variable(s) in PISM file {grid_file}"
+                )
+            mapping = {k: nc["mapping"].getncattr(k) for k in nc["mapping"].ncattrs()}
+
+        gm = mapping.get("grid_mapping_name", "").lower()
+        if gm != "polar_stereographic":
+            raise RuntimeError(f"Unsupported PISM projection: {gm!r}")
+
+        self.proj4 = (
+            f"+proj=stere "
+            f"+lat_0={mapping['latitude_of_projection_origin']} "
+            f"+lat_ts={mapping['standard_parallel']} "
+            f"+lon_0={mapping.get('straight_vertical_longitude_from_pole', 0.0)} "
+            f"+x_0={mapping.get('false_easting', 0.0)} "
+            f"+y_0={mapping.get('false_northing', 0.0)} "
+            f"+ellps={mapping.get('ellipsoid', 'WGS84')} +units=m +no_defs"
+        )
+
+    def _xy(self):
+        with Dataset(self.grid_file) as nc:
+            return (np.array(nc["x"][:], dtype=float),
+                    np.array(nc["y"][:], dtype=float))
+
+    def cell_latitudes(self):
+        with Dataset(self.grid_file) as nc:
+            return np.array(nc["lat"][:], dtype=float)
+
+    def cell_longitudes(self):
+        with Dataset(self.grid_file) as nc:
+            return np.array(nc["lon"][:], dtype=float)
+
+    def cell_corners(self):
+        """Corner lat/lon as (2, 4, ny, nx), ORCA convention (0=lat, 1=lon).
+
+        Counterclockwise seen from outside the sphere, as SCRIP wants.
+        """
+        x, y = self._xy()
+        dx = float(np.diff(x).mean())
+        dy = float(np.diff(y).mean())
+        xc = np.concatenate([x - dx / 2.0, [x[-1] + dx / 2.0]])
+        yc = np.concatenate([y - dy / 2.0, [y[-1] + dy / 2.0]])
+        XC, YC = np.meshgrid(xc, yc)
+
+        transformer = pyproj.Transformer.from_crs(
+            pyproj.CRS.from_proj4(self.proj4), "EPSG:4326", always_xy=True
+        )
+        lonc, latc = transformer.transform(XC, YC)
+
+        corners = np.empty((2, 4, *self.cell_latitudes().shape))
+        corners[0] = np.stack([latc[:-1, :-1], latc[:-1, 1:],
+                               latc[1:, 1:], latc[1:, :-1]])
+        corners[1] = np.stack([lonc[:-1, :-1], lonc[:-1, 1:],
+                               lonc[1:, 1:], lonc[1:, :-1]])
+        return corners
+
+    def cell_areas(self, earth_radius=6371229.0):
+        """Cell area [m2], spherical excess over two triangles.
+
+        Not a plane formula: the domain wraps the pole, so cells on the +/-180
+        meridian would get a lon span of ~2*pi instead of ~0.
+        """
+        corners = self.cell_corners()
+        lat, lon = corners[0], corners[1]
+
+        def unit(k):
+            la, lo = np.radians(lat[k]), np.radians(lon[k])
+            return np.stack([np.cos(la) * np.cos(lo),
+                             np.cos(la) * np.sin(lo),
+                             np.sin(la)], axis=0)
+
+        v = [unit(k) for k in range(4)]
+
+        def triangle(a, b, c):
+            num = np.abs(np.einsum("i...,i...->...", a, np.cross(b, c, axis=0)))
+            den = (1.0
+                   + np.einsum("i...,i...->...", a, b)
+                   + np.einsum("i...,i...->...", b, c)
+                   + np.einsum("i...,i...->...", c, a))
+            return 2.0 * np.arctan2(num, den) * earth_radius * earth_radius
+
+        return triangle(v[0], v[1], v[2]) + triangle(v[0], v[2], v[3])
+
+    def cell_masks(self):
+        """OASIS mask, 1 = excluded, 0 = active. All active.
+
+        Masking by ice cover would make the weights follow the ice geometry,
+        which defeats having a fixed grid.
+        """
+        return np.zeros(self.cell_latitudes().shape, dtype=np.int32)

--- a/ocp_tool/icmcl_dms.py
+++ b/ocp_tool/icmcl_dms.py
@@ -1,0 +1,180 @@
+"""Add the DMS surface-emission climatology to the OpenIFS ICMCL file.
+
+WHY THIS EXISTS.  OpenIFS marine cloud condensation nuclei come from Genthon (1992)
+sea-salt-from-wind alone (surfrad_ctl_mod.F90, LCCNO branch).  There is no biogenic
+term, and MACv2-SP -- the only other live CCN path -- is anthropogenic plumes only.  So
+natural marine biogenic sulphate is absent by construction, and the consequence is
+measurable: the model's Southern Ocean droplet number is correct in the mean
+(Nd ~ 73 cm-3, observed 60-120) but its SEASONAL PHASE IS INVERTED -- lowest in DJF
+(68.5) and highest in JJA (76.1), because it follows the wind, where observations peak in
+DJF with the biogenic bloom.  The measured SO shortwave CRE error is worst in exactly the
+months the model has fewest droplets (DJF +10.86, SON +13.11 W/m2).
+
+THE DATA ALREADY SHIPS AND NOTHING READS IT.  `climate.v020/<res>/month_dms` is a 12-month
+DMS surface-emission climatology (paramId 210043, kg m-2 s-1) provided by ECMWF at every
+resolution, already on the model's own reduced Gaussian grid.  It is not ingested: ICMCL
+carries only albedo and LAI, and OpenIFS references DMS solely in the TM5/M7 chemistry
+paths, which need NACTAERO /= 0.
+
+WHY THIS BELONGS IN OCP-TOOL AND NOT mkclimr.sh.  emdms is an OCEAN field carrying a -99
+sentinel over land -- the opposite convention to albedo and LAI, which are land fields.
+Under a changed coastline (any paleo configuration) new ocean points need infill and new
+land points need the sentinel.  ocp-tool already applies the land-sea mask to ICMCL in
+paleo_input.py (step 14b); mkclimr.sh cannot.  Putting the field here is what makes it
+paleo-safe.
+
+THE READER'S CONTRACT, which sets the output ordering.  ece_updclie_climr.F90 discovers
+the field list from the FIRST date and then requires every later date to repeat it in the
+same order, aborting with "Inconsistent order of fields in ICMCL*INIT" otherwise.  Fields
+are grouped BY DATE.  So the emdms message for each month must be interleaved into that
+month's group, not appended in a block at the end.
+
+Capacity was checked before writing this: NCLIGC is dimensioned 19, max_fields is 10, and
+CLIMR is allocated from the discovered count -- so an eighth field needs no model change
+to be READ.  That makes the file side testable on its own, before any physics is wired up.
+"""
+import eccodes as ecc
+
+DMS_PARAM_ID = 210043
+DMS_SHORTNAME = 'emdms'
+DMS_LAND_SENTINEL = -99.0
+
+
+def _messages(path):
+    """Yield (dataDate, paramId, shortName, raw_bytes) for every message."""
+    out = []
+    with open(path, 'rb') as f:
+        while True:
+            gid = ecc.codes_grib_new_from_file(f)
+            if gid is None:
+                break
+            rec = (ecc.codes_get(gid, 'dataDate'),
+                   ecc.codes_get(gid, 'paramId'),
+                   ecc.codes_get(gid, 'shortName'),
+                   ecc.codes_get_message(gid))
+            ecc.codes_release(gid)
+            out.append(rec)
+    return out
+
+
+def add_dms_to_icmcl(icmcl_in, dms_file, icmcl_out, land_sea_mask=None,
+                     verbose=True):
+    """Interleave the DMS climatology into ICMCL, one message per date group.
+
+    land_sea_mask, if given, is a 1-D array on the same reduced Gaussian grid with
+    1 = land.  It is used to RE-APPLY the sentinel consistently with the mask
+    ocp-tool has generated, which is the paleo-safe path: points that are ocean in
+    the new mask but carry the sentinel are filled from the field's own ocean mean,
+    and points that are land in the new mask are forced to the sentinel regardless
+    of what the source climatology said.
+
+    Returns the number of messages written.
+    """
+    icmcl = _messages(icmcl_in)
+    dms = _messages(dms_file)
+
+    dms_by_date = {}
+    for date, pid, name, raw in dms:
+        if pid != DMS_PARAM_ID:
+            continue
+        if date in dms_by_date:
+            raise RuntimeError(f'duplicate DMS message for date {date}')
+        dms_by_date[date] = raw
+    if not dms_by_date:
+        raise RuntimeError(f'no paramId {DMS_PARAM_ID} messages in {dms_file}')
+
+    icmcl_dates = []
+    for date, _, _, _ in icmcl:
+        if date not in icmcl_dates:
+            icmcl_dates.append(date)
+    missing = [d for d in icmcl_dates if d not in dms_by_date]
+    if missing:
+        raise RuntimeError(
+            f'ICMCL has dates with no DMS counterpart: {missing}. The reader groups '
+            'by dataDate and requires an identical field list per date, so a partial '
+            'merge would abort the model.')
+
+    if any(pid == DMS_PARAM_ID for _, pid, _, _ in icmcl):
+        raise RuntimeError(f'{icmcl_in} already contains paramId {DMS_PARAM_ID}')
+
+    # write each date group followed by that date's DMS message
+    n = 0
+    with open(icmcl_out, 'wb') as fout:
+        for i, (date, pid, name, raw) in enumerate(icmcl):
+            fout.write(raw)
+            n += 1
+            last_of_group = (i == len(icmcl) - 1) or (icmcl[i + 1][0] != date)
+            if last_of_group:
+                raw_dms = dms_by_date[date]
+                if land_sea_mask is not None:
+                    raw_dms = _remask(raw_dms, land_sea_mask)
+                fout.write(raw_dms)
+                n += 1
+
+    if verbose:
+        per_date = n // len(icmcl_dates)
+        print(f'  ICMCL + DMS: {len(icmcl)} -> {n} messages '
+              f'({len(icmcl_dates)} dates x {per_date} fields)')
+    return n
+
+
+def _remask(raw, land_sea_mask):
+    """Force the land sentinel to follow the supplied mask (paleo-safe)."""
+    gid = ecc.codes_new_from_message(raw)
+    try:
+        vals = ecc.codes_get_values(gid)
+        if len(vals) != len(land_sea_mask):
+            raise RuntimeError(
+                f'mask length {len(land_sea_mask)} does not match DMS field '
+                f'length {len(vals)}')
+        is_land = land_sea_mask >= 0.5
+        ocean_vals = vals[(~is_land) & (vals > DMS_LAND_SENTINEL / 2)]
+        fill = float(ocean_vals.mean()) if ocean_vals.size else 0.0
+        # new ocean (was sentinel, now sea) -> ocean mean; any land -> sentinel
+        vals = vals.copy()
+        vals[(~is_land) & (vals <= DMS_LAND_SENTINEL / 2)] = fill
+        vals[is_land] = DMS_LAND_SENTINEL
+        ecc.codes_set_values(gid, vals)
+        return ecc.codes_get_message(gid)
+    finally:
+        ecc.codes_release(gid)
+
+
+def verify(icmcl_out, expect_fields=8, verbose=True):
+    """Check the written file against the reader's contract.
+
+    Reproduces what ece_updclie_climr.F90 (setup_toc) does: read the field order from
+    the first date, then require every later date to match it exactly.  Catching a
+    violation here is seconds; catching it in the model is a failed run.
+    """
+    msgs = _messages(icmcl_out)
+    order, dates, cur, curdate = None, 0, [], None
+    for date, pid, name, _ in msgs:
+        if date != curdate:
+            if cur:
+                if order is None:
+                    order = cur
+                elif cur != order:
+                    raise RuntimeError(
+                        f'field order differs at date {curdate}: {cur} != {order} '
+                        '-- the model would abort with "Inconsistent order of fields"')
+                dates += 1
+            cur, curdate = [], date
+        cur.append(pid)
+    if cur:
+        if order is not None and cur != order:
+            raise RuntimeError(f'field order differs at final date {curdate}')
+        order = order or cur
+        dates += 1
+
+    if len(order) != expect_fields:
+        raise RuntimeError(f'expected {expect_fields} fields per date, got {len(order)}')
+    if DMS_PARAM_ID not in order:
+        raise RuntimeError(f'paramId {DMS_PARAM_ID} absent from the written file')
+    if len(order) > 10:
+        raise RuntimeError('more than max_fields=10 per date; the model would abort')
+
+    if verbose:
+        print(f'  verify: {dates} dates x {len(order)} fields, order {order} -- OK')
+        print(f'          within max_fields=10 and NCLIGC(19)')
+    return order

--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -151,30 +151,38 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
 
 
 def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
-                       method: str = "bilinear") -> List[Link]:
+                       method: str = "gauswgt") -> List[Link]:
     """Links for a PISM ice sheet coupled through the ISM-mapper.
 
-    Two links cover the whole field set, because a link is one (source, target,
-    map) and not one per field: everything OIFS sends the ISM-mapper
-    (A_Evap_ISM, A_SST_ISM, A_Soil4T_ISM, and the shared precip/runoff fields)
-    is atm -> ice, and plit is ice -> atm.
+    A link is one (source, target, map), not one per field, so the whole ISM
+    field set is three links. The SCRIPR letter is the SOURCE grid type: the
+    reduced-Gaussian atmosphere grids are D, the projected ice grid is LR.
 
-    ``method`` picks the ice -> atm map. "bilinear" reproduces EC-Earth.
-    "conserv" is likely the better choice for plit: it is a 0/1 mask on a 8 km
-    grid going to ~100 km cells, and what suorog thresholds against
-    ECE_LANDICE_THRESH is an area fraction, which conservative gives directly
-    and a centre-based interpolation does not. Needs corners on both grids.
+    ``method`` picks the ice -> atm map, "gauswgt" or "distwgt". Both BILINEAR
+    and CONSERV abort on a pole-centred grid: 381 of the 761x761 cells have a
+    corner longitude spread above 180 deg along the polar seam, and the pole
+    cell's corners encircle the pole outright, which breaks SCRIP's
+    enclosing-quadrilateral search and its per-cell longitude line integral.
+    So conservative is not available here, and plit reaches suorog as an
+    interpolated value rather than the area fraction ECE_LANDICE_THRESH reads.
     """
-    if method not in ("bilinear", "conserv"):
+    if method not in ("gauswgt", "distwgt"):
         raise ValueError(f"unknown method profile: {method}")
-    bilinear = "BILINEAR D SCALAR LATITUDE 15"
-    conserv = "CONSERV LR SCALAR LATITUDE 1 25 0.1"
+    bilinear_d = "BILINEAR D SCALAR LATITUDE 15"
+    gauswgt_d = "GAUSWGT D SCALAR LATITUDE 1 25 0.1"
+    gauswgt_lr = "GAUSWGT LR SCALAR LATITUDE 1 25 0.1"
+    distwgt_lr = "DISTWGT LR SCALAR LATITUDE 1 4"
+
+    # Runoff is on the runoff-mapper's atmosphere grid (A096 -> R096), not atma.
+    rnf_atm_grid = "R" + atm_grid[1:]
 
     return [
-        # atm -> ice: forcing. Coarse to fine, so a centre-based map is right.
-        Link(atm_grid, ice_grid, bilinear),
+        # atm -> ice: precip, evaporation, soil temperature, SST.
+        Link(atm_grid, ice_grid, bilinear_d),
+        # atm runoff grid -> ice: the R term of the direct P - E - R scheme.
+        Link(rnf_atm_grid, ice_grid, gauswgt_d),
         # ice -> atm: plit.
-        Link(ice_grid, atm_grid, conserv if method == "conserv" else bilinear),
+        Link(ice_grid, atm_grid, distwgt_lr if method == "distwgt" else gauswgt_lr),
     ]
 
 

--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -150,6 +150,34 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
     ]
 
 
+def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
+                       method: str = "bilinear") -> List[Link]:
+    """Links for a PISM ice sheet coupled through the ISM-mapper.
+
+    Two links cover the whole field set, because a link is one (source, target,
+    map) and not one per field: everything OIFS sends the ISM-mapper
+    (A_Evap_ISM, A_SST_ISM, A_Soil4T_ISM, and the shared precip/runoff fields)
+    is atm -> ice, and plit is ice -> atm.
+
+    ``method`` picks the ice -> atm map. "bilinear" reproduces EC-Earth.
+    "conserv" is likely the better choice for plit: it is a 0/1 mask on a 8 km
+    grid going to ~100 km cells, and what suorog thresholds against
+    ECE_LANDICE_THRESH is an area fraction, which conservative gives directly
+    and a centre-based interpolation does not. Needs corners on both grids.
+    """
+    if method not in ("bilinear", "conserv"):
+        raise ValueError(f"unknown method profile: {method}")
+    bilinear = "BILINEAR D SCALAR LATITUDE 15"
+    conserv = "CONSERV LR SCALAR LATITUDE 1 25 0.1"
+
+    return [
+        # atm -> ice: forcing. Coarse to fine, so a centre-based map is right.
+        Link(atm_grid, ice_grid, bilinear),
+        # ice -> atm: plit.
+        Link(ice_grid, atm_grid, conserv if method == "conserv" else bilinear),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Grid geometry read back from the OASIS description files
 # ---------------------------------------------------------------------------

--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -151,18 +151,12 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
 
 
 def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
-                       method: str = "gauswgt", freshwater: bool = False,
-                       rnf_grid: str = "RnfA") -> List[Link]:
+                       method: str = "gauswgt") -> List[Link]:
     """Links for a PISM ice sheet coupled through the ISM-mapper.
 
     A link is one (source, target, map), not one per field, so the whole ISM
     field set is three links. The SCRIPR letter is the SOURCE grid type: the
     reduced-Gaussian atmosphere grids are D, the projected ice grid is LR.
-
-    ``freshwater`` adds the ice -> runoff-mapper link, for the ice sheet's basal
-    melt and discharge. RnfA is a regular 512x256 lat-lon grid, so unlike the
-    ice -> atm case the target is not the awkward side; the source is still the
-    pole-centred ice grid, hence LR and a neighbour-based map.
 
     ``method`` picks the ice -> atm map, "gauswgt" or "distwgt". Both BILINEAR
     and CONSERV abort on a pole-centred grid: 381 of the 761x761 cells have a
@@ -182,7 +176,7 @@ def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
     # Runoff is on the runoff-mapper's atmosphere grid (A096 -> R096), not atma.
     rnf_atm_grid = "R" + atm_grid[1:]
 
-    links = [
+    return [
         # atm -> ice: precip, evaporation, soil temperature, SST.
         Link(atm_grid, ice_grid, bilinear_d),
         # atm runoff grid -> ice: the R term of the direct P - E - R scheme.
@@ -190,11 +184,6 @@ def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
         # ice -> atm: plit.
         Link(ice_grid, atm_grid, distwgt_lr if method == "distwgt" else gauswgt_lr),
     ]
-    if freshwater:
-        # ice -> runoff mapper: basal melt and discharge.
-        links.append(Link(ice_grid, rnf_grid,
-                          distwgt_lr if method == "distwgt" else gauswgt_lr))
-    return links
 
 
 # ---------------------------------------------------------------------------

--- a/ocp_tool/oasis_weights.py
+++ b/ocp_tool/oasis_weights.py
@@ -151,12 +151,18 @@ def awiesm3_feom_links(atm_grid: str = "A096", method: str = "existing") -> List
 
 
 def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
-                       method: str = "gauswgt") -> List[Link]:
+                       method: str = "gauswgt", freshwater: bool = False,
+                       rnf_grid: str = "RnfA") -> List[Link]:
     """Links for a PISM ice sheet coupled through the ISM-mapper.
 
     A link is one (source, target, map), not one per field, so the whole ISM
     field set is three links. The SCRIPR letter is the SOURCE grid type: the
     reduced-Gaussian atmosphere grids are D, the projected ice grid is LR.
+
+    ``freshwater`` adds the ice -> runoff-mapper link, for the ice sheet's basal
+    melt and discharge. RnfA is a regular 512x256 lat-lon grid, so unlike the
+    ice -> atm case the target is not the awkward side; the source is still the
+    pole-centred ice grid, hence LR and a neighbour-based map.
 
     ``method`` picks the ice -> atm map, "gauswgt" or "distwgt". Both BILINEAR
     and CONSERV abort on a pole-centred grid: 381 of the 761x761 cells have a
@@ -176,7 +182,7 @@ def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
     # Runoff is on the runoff-mapper's atmosphere grid (A096 -> R096), not atma.
     rnf_atm_grid = "R" + atm_grid[1:]
 
-    return [
+    links = [
         # atm -> ice: precip, evaporation, soil temperature, SST.
         Link(atm_grid, ice_grid, bilinear_d),
         # atm runoff grid -> ice: the R term of the direct P - E - R scheme.
@@ -184,6 +190,11 @@ def awiesm3_ismp_links(atm_grid: str = "A096", ice_grid: str = "ismp",
         # ice -> atm: plit.
         Link(ice_grid, atm_grid, distwgt_lr if method == "distwgt" else gauswgt_lr),
     ]
+    if freshwater:
+        # ice -> runoff mapper: basal melt and discharge.
+        links.append(Link(ice_grid, rnf_grid,
+                          distwgt_lr if method == "distwgt" else gauswgt_lr))
+    return links
 
 
 # ---------------------------------------------------------------------------

--- a/ocp_tool/oasis_writer.py
+++ b/ocp_tool/oasis_writer.py
@@ -83,6 +83,7 @@ def write_oasis_grid_files(
     # Add ice-sheet grids, off unless ice.enabled is set in the config
     if config.ice is not None:
         _append_pism_grid_to_oasis_files(config, file_types)
+        _write_ismm_restart(config)
 
 
 def _write_single_oasis_file(
@@ -253,6 +254,57 @@ def _append_fesom_grid_to_oasis_files(config: OCPConfig) -> None:
         print(f"Warning: Failed to add FESOM grid to OASIS files: {e}")
         import traceback
         traceback.print_exc()
+
+
+def _write_ismm_restart(config: OCPConfig, restart_name: str = "rstism.nc") -> None:
+    """Seed the ISM-mapper OASIS restart with the ice mask.
+
+    OASIS restarts hold the SOURCE field on the SOURCE grid and remap at read
+    time, so only <prefix>_plit is needed here; the atmosphere fluxes are safely
+    zero-filled by NNOREST. A mask is not: with LAG the receiver takes its first
+    value from this file, and an empty mask strips the glacier tiles from the
+    atmosphere for one coupling interval.
+    """
+    out = config.output_paths.oasis / restart_name
+    print(f' Writing ISM-mapper restart {out}')
+
+    wrote = []
+    for region in config.ice.regions:
+        try:
+            with Dataset(str(region.grid_file)) as src:
+                if "thk" not in src.variables:
+                    print(f'Warning: no thk in {region.grid_file}, skipping {region.name}')
+                    continue
+                thk = np.array(src.variables["thk"][:])
+        except Exception as e:
+            print(f'Warning: could not read {region.grid_file}: {e}')
+            continue
+
+        if thk.ndim == 3:
+            thk = thk[-1]
+        mask = np.where(thk > 0.0, 1.0, 0.0)
+
+        ny, nx = mask.shape
+        vn = f"{region.prefix}_plit"
+        mode = "a" if out.exists() else "w"
+        nc = Dataset(str(out), mode, format="NETCDF3_CLASSIC")
+        try:
+            yname, xname = f"ny_{region.name}", f"nx_{region.name}"
+            if yname not in nc.dimensions:
+                nc.createDimension(yname, ny)
+            if xname not in nc.dimensions:
+                nc.createDimension(xname, nx)
+            if vn not in nc.variables:
+                v = nc.createVariable(vn, "f8", (yname, xname))
+                v.units = "1"
+                v.long_name = "ice sheet mask, 1 = ice"
+                v[:] = mask
+                wrote.append(f"{vn} ({nx}x{ny}, {int(mask.sum())} ice cells)")
+        finally:
+            nc.close()
+
+    print(f"  {', '.join(wrote) if wrote else '(nothing written)'}")
+    print(f"\n {'='*50} \n")
 
 
 def _append_pism_grid_to_oasis_files(config: OCPConfig, file_types: list) -> None:

--- a/ocp_tool/oasis_writer.py
+++ b/ocp_tool/oasis_writer.py
@@ -72,11 +72,17 @@ def write_oasis_grid_files(
     # Copy runoff files into OASIS files (skip for AMIP mode - no ocean coupling)
     if config.ocean.grid_name != 'AMIP':
         _append_runoff_to_oasis_files(config, file_types)
-        # Add FESOM ocean grid to OASIS files
-        _append_fesom_grid_to_oasis_files(config)
+        if config.ocean.write_oasis_grid:
+            _append_fesom_grid_to_oasis_files(config)
+        else:
+            print(' Skipping FESOM grid export (FESOM writes feom at runtime)')
     else:
         # Add AMIP forcing-reader grid for SST/SIC forcing
         _append_amip_grid_to_oasis_files(config, file_types)
+
+    # Add ice-sheet grids, off unless ice.enabled is set in the config
+    if config.ice is not None:
+        _append_pism_grid_to_oasis_files(config, file_types)
 
 
 def _write_single_oasis_file(
@@ -247,6 +253,84 @@ def _append_fesom_grid_to_oasis_files(config: OCPConfig) -> None:
         print(f"Warning: Failed to add FESOM grid to OASIS files: {e}")
         import traceback
         traceback.print_exc()
+
+
+def _append_pism_grid_to_oasis_files(config: OCPConfig, file_types: list) -> None:
+    """Append each configured PISM ice-sheet domain to the OASIS files."""
+    from .grids import PISM
+
+    for region in config.ice.regions:
+        print(f' Adding PISM ice grid {region.name} from {region.grid_file}')
+        try:
+            grid = PISM(str(region.grid_file), name=region.name)
+            lats = grid.cell_latitudes()
+            lons = grid.cell_longitudes()
+            corners = grid.cell_corners()
+            areas = grid.cell_areas()
+            masks = grid.cell_masks()
+        except Exception as e:
+            print(f'Warning: failed to build PISM grid {region.name}: {e}')
+            import traceback
+            traceback.print_exc()
+            continue
+
+        ny, nx = lats.shape
+        name = region.name
+        xname, yname, crnname = f'x_{name}', f'y_{name}', f'crn_{name}'
+
+        for file_type in file_types:
+            oasis_file = config.output_paths.oasis / f'{file_type}.nc'
+            nc = Dataset(str(oasis_file), 'a')
+
+            if xname not in nc.dimensions:
+                nc.createDimension(xname, nx)
+            if yname not in nc.dimensions:
+                nc.createDimension(yname, ny)
+
+            if file_type == 'grids':
+                if crnname not in nc.dimensions:
+                    nc.createDimension(crnname, 4)
+                for vn, data, units, sname in (
+                    (f'{name}.lon', lons, 'degrees_east', 'Longitude'),
+                    (f'{name}.lat', lats, 'degrees_north', 'Latitude'),
+                ):
+                    if vn not in nc.variables:
+                        v = nc.createVariable(vn, 'float64', (yname, xname))
+                        v.units = units
+                        v.standard_name = sname
+                        v[:] = data
+                for vn, data, units, sname in (
+                    (f'{name}.clo', corners[1], 'degrees_east', 'Longitude corners'),
+                    (f'{name}.cla', corners[0], 'degrees_north', 'Latitude corners'),
+                ):
+                    if vn not in nc.variables:
+                        v = nc.createVariable(vn, 'float64', (crnname, yname, xname))
+                        v.units = units
+                        v.standard_name = sname
+                        v[:] = data
+
+            elif file_type == 'areas':
+                vn = f'{name}.srf'
+                if vn not in nc.variables:
+                    v = nc.createVariable(vn, 'float64', (yname, xname))
+                    v.units = 'm2'
+                    v.standard_name = 'Grid cell area'
+                    v[:] = areas
+
+            elif file_type == 'masks':
+                vn = f'{name}.msk'
+                if vn not in nc.variables:
+                    v = nc.createVariable(vn, 'int32', (yname, xname))
+                    v.units = '1'
+                    v.standard_name = 'Grid mask (0=active, 1=masked)'
+                    v[:] = masks
+
+            nc.close()
+
+        print(f'  {name}: {nx}x{ny}, total area {areas.sum()/1e12:.2f} x10^6 km2')
+
+    print(' PISM ice grid(s) added successfully')
+    print(f"\n {'='*50} \n")
 
 
 def _append_amip_grid_to_oasis_files(config: OCPConfig, file_types: list) -> None:


### PR DESCRIPTION
Groundwork for coupling PISM to AWI-ESM3 through the EC-Earth4 ISM-mapper. The ISM-mapper is an OASIS component, so a PISM domain has to appear in `grids.nc` / `masks.nc` / `areas.nc` and needs remap weights, and ocp-tool is where both already live.

Draft: the `plit` remap choice below is unresolved, and the esm_tools side that would exercise this is not written yet.

## What is here

- **`ocp_tool/grids/pism.py`** — a `PISM` grid class with the same five methods as `ORCA` (`cell_latitudes`, `cell_longitudes`, `cell_corners`, `cell_areas`, `cell_masks`), registered in `grids/factory()`.
- **`ocp_tool/config.py`** — `IceConfig` / `IceRegionConfig` / `_load_ice_config`, gated exactly like `paleo`.
- **`ocp_tool/oasis_writer.py`** — `_append_pism_grid_to_oasis_files`, alongside the existing runoff / FESOM / AMIP appends.
- **`ocp_tool/oasis_weights.py`** — `awiesm3_ismp_links()`. Two links cover the whole ISM field set, since a link is one `(source, target, map)` and not one per field.
- **`configs/TCO95_CORE3_ICE.yaml`** — `TCO95_CORE3.yaml` plus the `ice` section.

Centres come from the PISM file's own `lat`/`lon`. Corners are inverse-projected from the cell corner `(x, y)` using the projection in its `mapping` variable. Areas are spherical excess over two triangles rather than a plane formula: the domain wraps the pole, so cells on the ±180 meridian would otherwise get a longitude span of ~2π.

## Two things reviewers should not have to find

**1. This changes default output for every FESOM config.** `feom` was being appended to the OASIS files unconditionally. FESOM writes its own `feom` entry at runtime in domain-decomposition order, and what ocp-tool writes is mesh order, so the two disagree — `permute_feom_to_runtime.py` in esm_tools exists because of that difference. It is now behind `ocean.write_oasis_grid`, **default off**, so `feom` no longer appears unless a config asks for it. Set `write_oasis_grid: true` to restore the old behaviour.

Everything else is additive and inert without `ice.enabled`.

**2. The `plit` remap is an open decision.** `awiesm3_ismp_links(method=...)` defaults to `"bilinear"`, reproducing EC-Earth. I think `"conserv"` is actually right for the ice→atm direction: `plit` is a 0/1 mask on 8 km cells landing on ~100 km cells, and what OIFS `suorog` compares against `ECE_LANDICE_THRESH` is an area fraction. Conservative gives that directly; a centre-based map gives an interpolated value that only resembles one. The `suorog` comment already describes it as a "fractional ice sheet mask (plit, 0-1 after regridding)". Left as bilinear so the reference behaviour is what you get without asking, but worth settling before weights are generated in anger.

## Verification

Grid geometry checked three ways on `antarct_cr` 8 km, 761×761, since a wrong grid fails as silently-bad weights rather than a crash:

- Spherical-excess area totals **36.03** against **36.28** ×10⁶ km² from the plane area corrected by the polar stereographic scale factor, a 0.70% spread.
- Cell areas run **67.0 km²** at the pole to **53.8** at the outer corner against a nominal 64 — the right sign and size for `lat_ts = -71`, where the scale factor is 0.973 at the pole and 1.089 at the grid edge.
- All 579121 cells wind **counterclockwise seen from outside the sphere**, no sign flips. SCRIP requires this and the area check cannot detect it, since the excess formula takes an absolute value.

A full TCO95/CORE3 run completes and puts `ismp` in all three OASIS files at 761×761 with `crn_ismp = 4`, bit-identical (`max|diff| = 0` on `lon`, `lat`, `clo`, `cla`, `srf`) to an independently generated reference, with `feom` correctly absent.

## Noted, not fixed

`_append_fesom_grid_to_oasis_files` guards its optional import with `except ImportError`, but `import pyfesom2` raises `AttributeError` when cmocean meets a matplotlib new enough to have dropped `matplotlib.cm.register_cmap`, so the whole run dies instead of skipping. Left alone deliberately: widening the catch would turn a loud failure into OASIS files silently missing the ocean grid, which fails far more confusingly later. It is also moot on the default path now, since that function is no longer called unless asked for.
