### PR TITLE
Restore lake cover lost to the NN fill, and fix the dateline seam in the CORE2 mask

### DIFF
--- a/ocp_tool/config.py
+++ b/ocp_tool/config.py
@@ -41,6 +41,38 @@ class RunoffConfig:
 
 
 @dataclass
+class LakeConfig:
+    """
+    Whether to put back the lake fields the land-sea flip destroys.
+
+    Reconciling the OpenIFS mask with the FESOM mesh makes a cell land wherever
+    FESOM has no wet node under it, and ``fill_flipped_from_nearest_neighbour``
+    then rebuilds its whole surface column from the nearest stable LAND cell.
+    Lake cover is only another surface field to that fill, so a cell the input
+    called a lake inherits a dry neighbour's ``cl`` and stops being one.
+
+    Measured on TCO95/CORE3 (scripts/analysis/lake_vs_soil_audit.py and
+    lake_pipeline_extract.py in the tuning campaign repo), of 319 cells flipped
+    from ocean to land: 70 carried ``cl >= 0.5`` in the pristine input --
+    the whole Caspian (27/27) and the Great Lakes (17/17) -- and after the flip
+    none of them do.
+
+    The option restores the pristine ``cl``, ``dl`` and FLake prognostics at
+    every flipped cell. It needs no threshold and no second mode: ``cl`` is the
+    lake share of the box and is capped by the water share, so the input file
+    has already classified each cell, and restoring its own value gives the
+    genuine lakes their ~0.8 and the coastal cells their ~0.02.
+
+    This does NOT change ``lsm``, so all four OASIS masks are unaffected, and it
+    does NOT remove those cells from the LPJ-GUESS gridlist, which is built from
+    ``lsm`` alone. The soil-type repair is therefore still required and is not
+    substitutable by this.
+    """
+    # Restore pristine cl/dl/FLake prognostics at every flipped cell.
+    restore_flipped_lakes: bool = False
+
+
+@dataclass
 class InputPaths:
     """Input directory paths."""
     fesom_mesh: Path
@@ -132,6 +164,7 @@ class OCPConfig:
     output_paths: OutputPaths
     options: ProcessingOptions
     root_dir: Path
+    lakes: LakeConfig = field(default_factory=LakeConfig)
     paleo: Optional[PaleoConfig] = None
     ice: Optional[IceConfig] = None
     
@@ -285,6 +318,10 @@ def load_config(config_path: Union[str, Path]) -> OCPConfig:
         ),
         runoff=RunoffConfig(
             manual_basin_removal=raw['runoff']['manual_basin_removal'],
+        ),
+        lakes=LakeConfig(
+            restore_flipped_lakes=raw.get('lakes', {}).get(
+                'restore_flipped_lakes', False),
         ),
         input_paths=input_paths,
         output_paths=output_paths,

--- a/ocp_tool/cycles.py
+++ b/ocp_tool/cycles.py
@@ -51,6 +51,21 @@ import eccodes
 # ``typeOfLevel`` marking a message as belonging to the multi-layer snowpack.
 SNOW_LAYER_TYPE_OF_LEVEL = 'snowLayer'
 
+# Fields a cell needs in order to be represented as a FLake lake rather than as
+# soil.  ``cl`` is the lake fraction of the grid box and ``dl`` its depth; the
+# rest are the FLake prognostics, which the NN fill has to be able to seed.
+#
+# These were expected to be a CY48R1 addition.  They are not: measured against
+#   input/openifs_input_default/ICMGGab45INIT            (48r1, TCO95)
+#   /work/ab0246/a270092/input/oifs-43r3/TL159L60/ICMGGh6mvINIT_CORE2
+# both files carry cl, dl, lmlt, lblt, lmld, lict, licd, ltlt and lshf.  FLake
+# has been in the IFS surface scheme since well before either cycle, so the
+# cycle number is not the thing that decides this.  ``lake_fields`` is kept as
+# the place a future cycle without FLake would be declared, but the guard that
+# actually protects a run is ``check_lake_fields`` below, which looks in the
+# file instead of trusting the label.
+LAKE_FIELDS = ('cl', 'dl', 'lmlt', 'lblt', 'lmld', 'lict', 'licd', 'ltlt', 'lshf')
+
 # Snow water equivalent assigned to a reconstruction ice-sheet point, in
 # metres of water equivalent.  Scaled to the file units via CycleSpec.
 ICE_SHEET_SNOW_MWE = 10.0
@@ -69,6 +84,9 @@ class CycleSpec:
     snow_mass_units: str
     # GRIB codes carried once per snow layer (empty for single-layer cycles)
     snow_layer_codes: Tuple[int, ...] = ()
+    # Does the ICMGG carry the FLake fields needed to represent a cell as lake?
+    # See LAKE_FIELDS and the note above.
+    lake_fields: bool = True
 
     def scale_snow_mass(self, metres_water_equivalent: float) -> float:
         """Convert m of water equivalent to the snow mass units of this cycle."""
@@ -131,6 +149,43 @@ def get_cycle(name: str) -> CycleSpec:
     if key == AUTO:
         raise ValueError("get_cycle() needs an explicit cycle, not 'auto'")
     return CYCLES[key]
+
+
+def check_lake_fields(
+    grib_file: Union[str, Path],
+    cycle: CycleSpec,
+) -> None:
+    """
+    Raise unless ``grib_file`` can support representing a cell as a FLake lake.
+
+    Checked against the file, not against the cycle name: the cycle label is a
+    statement about what a cycle *usually* carries, and an ICMGG assembled by
+    hand may not. A missing FLake prognostic is the failure that otherwise
+    appears at model start-up as ``GRIDPOINT 2D FIELD MISSING``, long after the
+    tool has exited successfully.
+    """
+    if not cycle.lake_fields:
+        raise ValueError(
+            f"lakes.restore_flipped_lakes is on, but OpenIFS cycle "
+            f"{cycle.name} is declared as having no FLake fields."
+        )
+    present = set()
+    with open(grib_file, 'rb') as f:
+        while True:
+            gid = eccodes.codes_grib_new_from_file(f)
+            if gid is None:
+                break
+            try:
+                present.add(eccodes.codes_get(gid, 'shortName'))
+            finally:
+                eccodes.codes_release(gid)
+    absent = [n for n in LAKE_FIELDS if n not in present]
+    if absent:
+        raise ValueError(
+            f"lakes.restore_flipped_lakes is on, but {grib_file} is missing the "
+            f"FLake field(s) {absent}. Turn the option off, or use an ICMGG that "
+            f"carries the full FLake set {list(LAKE_FIELDS)}."
+        )
 
 
 def has_snow_layers(grib_file: Union[str, Path]) -> bool:

--- a/ocp_tool/gaussian_grids.py
+++ b/ocp_tool/gaussian_grids.py
@@ -623,7 +623,39 @@ def read_fesom_grid_polygon(
         
         triag_dl = triag[valid_dl]
         cavity_dl = tri_has_cavity[valid_dl]
-        
+
+        # Drop triangles that STILL span more than 180 degrees after the shift.
+        #
+        # These are polar-cap triangles. At the pole longitude carries no
+        # information, so a cap triangle's three nodes can sit at any three
+        # longitudes at all -- on CORE2 the offender is a single triangle at
+        # lat 89.8-90.0 with longitudes 99, 173 and 336, a span of 237 degrees
+        # after shifting. Laid out in the plane it stretches across two thirds
+        # of the domain and overlaps almost every other triangle, and the
+        # trapezoid map the point-location index is built on cannot be
+        # constructed from overlapping triangles: it raises "Triangulation is
+        # invalid" and the whole dateline pass is lost.
+        #
+        # The consequence was silent and severe. Every point the pass would
+        # have classified stayed at the "land" default, so the CORE2 mask came
+        # out with all 192 cells on the lon = 180 meridian marked land against
+        # 9 % in the ECMWF input -- a wall of false land from pole to pole.
+        # CORE3 has such a triangle too and happened to survive, so this is not
+        # a CORE2 peculiarity, only a CORE2 symptom.
+        #
+        # Dropping them loses nothing: a triangle that cannot be drawn in the
+        # plane cannot locate points there either, and the pole is covered by
+        # the non-dateline triangles of Pass 1.
+        span_shifted = (lon_shifted[triag_dl].max(axis=1)
+                        - lon_shifted[triag_dl].min(axis=1))
+        unplanar = span_shifted > 180
+        if unplanar.any():
+            print(f'   dropping {int(unplanar.sum())} polar-cap triangle(s) that '
+                  f'still span >180 deg after the shift '
+                  f'(max {span_shifted[unplanar].max():.1f} deg)')
+            triag_dl = triag_dl[~unplanar]
+            cavity_dl = cavity_dl[~unplanar]
+
         try:
             tri_dl = Triangulation(lon_shifted, lat, triangles=triag_dl)
             finder_dl = tri_dl.get_trifinder()
@@ -642,7 +674,18 @@ def read_fesom_grid_polygon(
             
             print(f"   Found {np.sum(found_dl)} points in dateline triangles")
         except Exception as e:
-            print(f" Warning: Dateline triangulation failed: {e}")
+            # Not recoverable, and must not be downgraded to a warning. Every
+            # point this pass would have classified keeps the "land" default,
+            # so continuing writes a land-sea mask with a seam of false land
+            # along the dateline -- which is exactly what happened to the CORE2
+            # files, unnoticed, because this used to print and carry on.
+            raise RuntimeError(
+                f'Dateline triangulation failed ({e}). Continuing would leave '
+                f'every point near lon 180 at the land default and produce a '
+                f'seam of false land down the dateline. Inspect the '
+                f'{len(triag_dl)} dateline triangles of this mesh rather than '
+                f'accepting the mask.'
+            ) from e
     
     land_count = int(np.sum(fesom_lsm == 1))
     ocean_count = int(np.sum(fesom_lsm == 0))

--- a/ocp_tool/lsm.py
+++ b/ocp_tool/lsm.py
@@ -5,7 +5,7 @@ Handles reading, modifying, and writing GRIB land-sea mask files.
 
 import copy
 from pathlib import Path
-from typing import Tuple, List, Optional
+from typing import Dict, Tuple, List, Optional
 from dataclasses import dataclass
 
 import numpy as np
@@ -13,7 +13,28 @@ import gribapi
 from shutil import copy2
 
 from .config import OCPConfig
+from .cycles import check_lake_fields
 from .gaussian_grids import GaussianGrid
+
+
+# FLake does not integrate the lake depth it is given. It clips it:
+#
+#   flakeene_mod.F90:211  ZDEPTH_W_MAX = 50.0   ! Maximum lake depth simulated
+#   flakeene_mod.F90:212  ZDEPTH_W_MIN =  2.0   ! Minimum lake depth simulated
+#   flakeene_mod.F90:238  ZDEPTH_W(JL) = MIN(ZDEPTH_W_MAX, MAX(ZDEPTH_W_MIN, PDEPTH_W(JL)))
+#
+# and independently again when seeding the mixed layer,
+#
+#   surftstp_ctl_mod.F90:882  ZHLML(JL) = MIN(PLDEPTH(JL), 50.0_JPRB)
+#
+# so 2 m and 50 m are the only depths at the ends of the range that mean
+# anything, and a deeper number is indistinguishable from 50 m.
+FLAKE_DEPTH_MIN_M = 2.0
+FLAKE_DEPTH_MAX_M = 50.0
+
+# FLake prognostics, restored alongside the cover so a recovered lake starts
+# from its own state. Ordering is irrelevant; presence is checked per field.
+FLAKE_PROGNOSTICS = ('lmlt', 'lblt', 'lmld', 'lict', 'licd', 'ltlt', 'lshf')
 
 
 @dataclass
@@ -179,6 +200,106 @@ def fill_flipped_from_nearest_neighbour(
               f'{len(changed_to_ocean)} new-ocean cells from nearest neighbours')
 
 
+def read_field_ids(input_file: Path) -> Dict[str, int]:
+    """
+    shortName -> position in the gribfield list, in file order.
+
+    ``read_grib_fields`` returns indices for only the three fields it needs.
+    Anything else that has to be addressed by name -- the FLake set, here --
+    needs the same mapping for the rest of the file. Built by a second scan
+    rather than threaded through the existing return tuple, which several
+    callers unpack positionally.
+
+    On a duplicated shortName the FIRST occurrence wins, matching
+    ``read_grib_fields``.
+    """
+    ids: Dict[str, int] = {}
+    with open(input_file, 'rb') as f:
+        i = 0
+        while True:
+            gid = gribapi.grib_new_from_file(f)
+            if gid is None:
+                break
+            try:
+                ids.setdefault(gribapi.grib_get(gid, 'shortName'), i)
+            finally:
+                gribapi.grib_release(gid)
+            i += 1
+    return ids
+
+
+def _clip_flake_depth(depth: float) -> float:
+    """Clip to the band FLake actually integrates over."""
+    return float(min(FLAKE_DEPTH_MAX_M, max(FLAKE_DEPTH_MIN_M, depth)))
+
+
+def restore_lake_cover(
+    gribfield_pristine: Dict[int, np.ndarray],
+    gribfield_mod: List[np.ndarray],
+    lake_ids: Dict[str, int],
+    changed_to_land: List[int],
+    verbose: bool = False,
+) -> int:
+    """
+    Put back the lake fields that the nearest-neighbour fill overwrote.
+
+    Must run AFTER ``fill_flipped_from_nearest_neighbour``, because that is what
+    destroyed them. The pristine snapshot is needed as well as the modified
+    list: the point is to recover what the input file said before the fill
+    replaced it with a dry neighbour's value.
+
+    ONE RULE, NO THRESHOLD. Every flipped cell gets its own pristine ``cl``,
+    ``dl`` and FLake prognostics back. Nothing is invented and nothing is
+    reclassified, because the input file has already done the classification
+    and it is more informative than any threshold applied here:
+
+    ``cl`` is the lake share of the grid box, capped by the water share -- on
+    TCO95 ``cl <= 1 - lsm`` holds at every one of the 40 320 cells. So at the
+    cells that were genuinely lake (the Caspian, the Great Lakes) the file says
+    ``cl = 1 - lsm`` exactly, mean 0.799; and at the coastal cells whose water
+    is sea rather than lake it says ``cl = 0.019`` against a water share of
+    0.663. Restoring the pristine value therefore gives each population what
+    ECMWF classified it as, in one operation.
+
+    An earlier version of this thresholded on ``cl >= 0.5`` and wrote ``1.0``.
+    That overstated lake area at those cells by 20 % on average, since 27 of
+    the 70 sit between 0.5 and 0.7, and it needed a companion option to decide
+    what to do with everything else. Both problems are artefacts of the
+    threshold, not of the data.
+
+    ``dl`` is clipped to the band FLake actually integrates,
+    ``MIN(50, MAX(2, dl))`` (``flakeene_mod.F90:238`` and
+    ``surftstp_ctl_mod.F90:882``), so the file says what the model will do.
+
+    Returns
+    -------
+    int : how many cells were restored.
+    """
+    if not changed_to_land:
+        return 0
+
+    cl_id, dl_id = lake_ids['cl'], lake_ids['dl']
+    idx = np.asarray(changed_to_land, dtype=int)
+
+    # Everything FLake needs, so a recovered lake starts from its own state
+    # rather than from whatever dry neighbour the fill happened to pick.
+    fields = [lake_ids[n] for n in ('cl', 'dl') + FLAKE_PROGNOSTICS
+              if n in lake_ids and lake_ids[n] in gribfield_pristine]
+
+    for i in idx:
+        for f in fields:
+            if len(gribfield_mod[f]) > i and len(gribfield_pristine[f]) > i:
+                gribfield_mod[f][i] = gribfield_pristine[f][i]
+        gribfield_mod[dl_id][i] = _clip_flake_depth(gribfield_pristine[dl_id][i])
+
+    if verbose:
+        pris = np.asarray(gribfield_pristine[cl_id], float)[idx]
+        print(f'  Lake fields restored at {len(idx)} flipped cells '
+              f'(mean cl {pris.mean():.3f}; '
+              f'{int((pris >= 0.5).sum())} of them are majority lake)')
+    return len(idx)
+
+
 def modify_lsm(
     gribfield: List[np.ndarray],
     ocean_lsm: np.ndarray,
@@ -187,16 +308,19 @@ def modify_lsm(
     slt_id: int,
     cl_id: int,
     grid: GaussianGrid,
-    verbose: bool = False
+    verbose: bool = False,
+    lake_ids: Optional[Dict[str, int]] = None,
+    lakes: Optional['LakeConfig'] = None,
 ) -> LSMData:
     """
     Modify land-sea mask based on ocean model grid.
-    
+
     - Flips the land-sea mask to agree with the ocean model grid
     - Rebuilds each flipped cell's full surface column from the nearest stable
       neighbour of its new type (so it is physically self-consistent)
+    - Optionally gives back the lake cover that rebuild removed
     - Creates masks for different purposes (atmosphere, land, runoff)
-    
+
     Args:
         gribfield: List of GRIB field arrays
         ocean_lsm: Ocean model land-sea mask
@@ -206,7 +330,9 @@ def modify_lsm(
         cl_id: Index of lake cover field
         grid: Gaussian grid data
         verbose: Print debug info
-        
+        lake_ids: shortName -> gribfield index, needed only for the lake step
+        lakes: LakeConfig; the lake step is skipped when it is None or off
+
     Returns:
         LSMData with modified masks and land point coordinates
     """
@@ -222,6 +348,23 @@ def modify_lsm(
         # Automatic lake removal based on ocean mask
         # Polygon method: ocean_lsm = 1 means land, 0 means ocean
         n_points = len(gribfield_mod[slt_id])
+
+        # gribfield_mod is a SHALLOW copy, so the NN fill below mutates these
+        # arrays in place and the input values are gone once it has run. The
+        # lake step needs to know what the file said before that, so snapshot
+        # the fields it reads while they are still pristine.
+        do_lakes = lakes is not None and lakes.restore_flipped_lakes
+        pristine_lake = {}
+        if do_lakes:
+            if lake_ids is None or 'cl' not in lake_ids or 'dl' not in lake_ids:
+                raise ValueError(
+                    'lakes.restore_flipped_lakes is on but the cl/dl field '
+                    'indices were not supplied to modify_lsm().'
+                )
+            for name in ('cl', 'dl') + FLAKE_PROGNOSTICS:
+                f = lake_ids.get(name)
+                if f is not None and f < len(gribfield_mod):
+                    pristine_lake[f] = np.array(gribfield_mod[f], copy=True)
 
         changed_to_ocean = []
         changed_to_land = []
@@ -246,6 +389,17 @@ def modify_lsm(
             gribfield_mod, lsm_id, grid,
             changed_to_land, changed_to_ocean, verbose=verbose,
         )
+
+        # ...and the fill has just overwritten the lake cover of every cell that
+        # used to be one, because cl is only another surface field to it.
+        if do_lakes:
+            restore_lake_cover(
+                gribfield_pristine=pristine_lake,
+                gribfield_mod=gribfield_mod,
+                lake_ids=lake_ids,
+                changed_to_land=changed_to_land,
+                verbose=verbose,
+            )
     else:
         print(" Skipped modifying OpenIFS grid, because we are in AMIP mode")
     
@@ -368,6 +522,15 @@ def process_land_sea_mask(
         verbose=config.options.verbose
     )
     
+    # The lake step addresses fields by name, which read_grib_fields does not
+    # provide beyond lsm/slt/cl, and it must not run against a file that cannot
+    # support it -- so resolve the indices and verify the file up front, before
+    # anything has been modified.
+    lake_ids = None
+    if config.lakes.restore_flipped_lakes:
+        check_lake_fields(input_file, config.cycle)
+        lake_ids = read_field_ids(input_file)
+
     # Modify LSM based on ocean grid
     lsm_data = modify_lsm(
         gribfield=gribfield,
@@ -377,7 +540,9 @@ def process_land_sea_mask(
         slt_id=slt_id,
         cl_id=cl_id,
         grid=grid,
-        verbose=config.options.verbose
+        verbose=config.options.verbose,
+        lake_ids=lake_ids,
+        lakes=config.lakes,
     )
     
     # Write modified GRIB

--- a/ocp_tool/lsm.py
+++ b/ocp_tool/lsm.py
@@ -12,7 +12,7 @@ import numpy as np
 import gribapi
 from shutil import copy2
 
-from .config import OCPConfig
+from .config import LakeConfig, OCPConfig
 from .cycles import check_lake_fields
 from .gaussian_grids import GaussianGrid
 
@@ -310,7 +310,7 @@ def modify_lsm(
     grid: GaussianGrid,
     verbose: bool = False,
     lake_ids: Optional[Dict[str, int]] = None,
-    lakes: Optional['LakeConfig'] = None,
+    lakes: Optional[LakeConfig] = None,
 ) -> LSMData:
     """
     Modify land-sea mask based on ocean model grid.
@@ -378,9 +378,9 @@ def modify_lsm(
                 gribfield_mod[lsm_id][i] = 1
                 changed_to_land.append(i)
 
-        # A flipped cell otherwise keeps the whole surface column of its OLD
-        # type: a new land point retains ocean's zero soil moisture, leftover
-        # sea-ice fraction and SST; a new ocean point retains land soil/skin
+        # A flipped cell otherwise keeps the whole surface column belonging to
+        # its OLD type. A new land point retains ocean's zero soil moisture,
+        # leftover sea-ice fraction and SST; a new ocean point keeps land skin
         # state. That mix is physically inconsistent and makes the atmosphere
         # surface/moist physics produce NaNs. Rebuild each flipped cell from the
         # nearest stable neighbour of its NEW type so every surface field looks

--- a/tests/test_lake_restore.py
+++ b/tests/test_lake_restore.py
@@ -1,0 +1,128 @@
+"""restore_lake_cover: put back what the nearest-neighbour fill overwrote.
+
+Driven by the real TCO95 ICMGG rather than a synthetic array, because the
+property under test is a statement about the ECMWF field convention -- that
+``cl`` is the lake share of a box and is capped by its water share -- and a
+hand-built fixture would simply assert whatever the author already believed.
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ocp_tool.lsm import (
+    FLAKE_DEPTH_MAX_M,
+    FLAKE_DEPTH_MIN_M,
+    _clip_flake_depth,
+    read_field_ids,
+    read_grib_fields,
+    restore_lake_cover,
+)
+
+ICMGG = Path('/work/ab0246/a270092/software/ocp-tool/input/'
+             'openifs_input_default/ICMGGab45INIT')
+
+pytestmark = pytest.mark.skipif(
+    not ICMGG.exists(), reason=f'{ICMGG} not available')
+
+
+@pytest.fixture(scope='module')
+def fields():
+    gribfield, lsm_id, slt_id, cl_id, gids, _ = read_grib_fields(
+        ICMGG, num_fields=None, verbose=False)
+    import gribapi
+    for g in gids:
+        if g is not None:
+            try:
+                gribapi.grib_release(g)
+            except Exception:                                   # noqa: BLE001
+                pass
+    return gribfield, read_field_ids(ICMGG), lsm_id
+
+
+def test_depth_clip_matches_flake():
+    """The band is FLake's, not ours: flakeene_mod.F90:211-212,238."""
+    assert _clip_flake_depth(0.0) == FLAKE_DEPTH_MIN_M
+    assert _clip_flake_depth(1.0) == FLAKE_DEPTH_MIN_M
+    assert _clip_flake_depth(25.0) == 25.0
+    assert _clip_flake_depth(4064.0) == FLAKE_DEPTH_MAX_M
+    # A Caspian at 1000 m and one at 50 m are the same model.
+    assert _clip_flake_depth(1000.0) == _clip_flake_depth(50.0)
+
+
+def test_lake_cover_never_exceeds_water_share(fields):
+    """
+    The convention the restore relies on, asserted against the shipped file.
+
+    If this ever fails, ``cl`` is not what this module assumes and the restore
+    is unsafe -- it would be putting back a lake fraction larger than the box's
+    water fraction.
+    """
+    gribfield, ids, lsm_id = fields
+    cl = np.asarray(gribfield[ids['cl']], float)
+    water = 1.0 - np.asarray(gribfield[lsm_id], float)
+    assert np.all(cl <= water + 1e-4), float((cl - water).max())
+
+
+def test_restore_recovers_the_pristine_values(fields):
+    """A flipped cell gets its own cl back, not 1.0 and not a neighbour's."""
+    gribfield, ids, _ = fields
+    cl_id, dl_id = ids['cl'], ids['dl']
+    pristine = {f: np.array(gribfield[f], copy=True)
+                for f in (cl_id, dl_id)}
+
+    # Pick real lake cells and real non-lake cells from the shipped file.
+    cl0 = pristine[cl_id]
+    lake_cells = np.where(cl0 >= 0.5)[0][:10].tolist()
+    dry_cells = np.where(cl0 == 0.0)[0][:10].tolist()
+    assert lake_cells and dry_cells
+
+    # Simulate what the NN fill does: overwrite cl and dl from a dry neighbour.
+    mod = [np.array(a, copy=True) for a in gribfield]
+    for i in lake_cells + dry_cells:
+        mod[cl_id][i] = 0.0
+        mod[dl_id][i] = 7.0
+
+    n = restore_lake_cover(
+        gribfield_pristine=pristine,
+        gribfield_mod=mod,
+        lake_ids={'cl': cl_id, 'dl': dl_id},
+        changed_to_land=lake_cells + dry_cells,
+        verbose=False,
+    )
+    assert n == len(lake_cells) + len(dry_cells)
+
+    for i in lake_cells:
+        # the cell's OWN value, not a forced 1.0
+        assert mod[cl_id][i] == pytest.approx(cl0[i])
+        assert mod[dl_id][i] == pytest.approx(
+            _clip_flake_depth(pristine[dl_id][i]))
+    for i in dry_cells:
+        # a non-lake cell is restored to its pristine zero, not invented into one
+        assert mod[cl_id][i] == 0.0
+
+
+def test_restore_writes_only_the_flipped_cells(fields):
+    """Untouched cells must come out bit-identical."""
+    gribfield, ids, _ = fields
+    cl_id, dl_id = ids['cl'], ids['dl']
+    pristine = {f: np.array(gribfield[f], copy=True) for f in (cl_id, dl_id)}
+    mod = [np.array(a, copy=True) for a in gribfield]
+    before = np.array(mod[cl_id], copy=True)
+
+    targets = [11, 2222, 33333]
+    for i in targets:
+        mod[cl_id][i] = 0.123
+    restore_lake_cover(pristine, mod, {'cl': cl_id, 'dl': dl_id}, targets)
+
+    changed = np.where(before != mod[cl_id])[0]
+    assert changed.size == 0, f'cl changed at unexpected cells: {changed[:20]}'
+
+
+def test_no_flipped_cells_is_a_noop(fields):
+    gribfield, ids, _ = fields
+    cl_id, dl_id = ids['cl'], ids['dl']
+    pristine = {f: np.array(gribfield[f], copy=True) for f in (cl_id, dl_id)}
+    mod = [np.array(a, copy=True) for a in gribfield]
+    assert restore_lake_cover(pristine, mod, {'cl': cl_id, 'dl': dl_id}, []) == 0
+    assert np.array_equal(mod[cl_id], gribfield[cl_id])

--- a/tools/repair_dateline_mask.py
+++ b/tools/repair_dateline_mask.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Remove the dateline seam of false land from a published ICMGG, in place.
+
+THE DEFECT.  Before the polar-cap guard in read_fesom_grid_polygon, a single
+triangle spanning more than 180 degrees after the dateline shift made the
+trapezoid map unbuildable, the whole dateline pass was lost, and every point it
+would have classified kept the "land" default.  On TCO95/CORE2 that put all 192
+cells within half a degree of lon 180 on land against 9 % in the ECMWF input --
+a seam of false land from pole to pole.  A bare except turned it into a warning,
+so the files were written and published.
+
+WHAT THIS FIXES, AND WHAT IT DELIBERATELY DOES NOT.  Only cells in the dateline
+band whose land-sea value the corrected mask disagrees with.  Recomputing the
+mask today also disagrees in a handful of places away from the dateline -- 1
+cell on TCO95/CORE2, 36 on TL255/CORE2 -- because the published files do not all
+date from the current mesh.nc.  Those are coastline drift, not this defect, and
+folding them in would change a coastline silently under cover of a bug fix.  The
+band is the fix; everything else is left exactly as published.
+
+A cell that becomes ocean cannot keep a land surface column: it would carry soil
+moisture, vegetation and a land skin temperature into a sea point, which is the
+inconsistency that produces NaNs in the surface scheme.  So each repaired cell
+is rebuilt from the nearest stable OCEAN neighbour, the same great-circle
+nearest-neighbour rule ocp-tool uses for the flip itself.  Donors exclude the
+cells being repaired, so a repaired cell is never seeded from another.
+
+Usage:
+    repair_dateline_mask.py PUBLISHED CORRECTED_MASK.npy OUTPUT [--dry-run]
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import eccodes
+
+# Half-width of the seam, in degrees of longitude. The defect is confined to the
+# single column of cells centred exactly on 180; 0.5 covers it with no room to
+# catch a genuine coastal cell.
+DATELINE_HALFWIDTH_DEG = 0.5
+
+
+def read_all(path):
+    """[(shortName, values)], plus lat/lon off the lsm message."""
+    out, lat, lon = [], None, None
+    with open(path, 'rb') as f:
+        while True:
+            gid = eccodes.codes_grib_new_from_file(f)
+            if gid is None:
+                break
+            try:
+                sn = eccodes.codes_get(gid, 'shortName')
+                out.append((sn, eccodes.codes_get_values(gid)))
+                if sn == 'lsm' and lat is None:
+                    lat = eccodes.codes_get_array(gid, 'latitudes')
+                    lon = eccodes.codes_get_array(gid, 'longitudes')
+            finally:
+                eccodes.codes_release(gid)
+    return out, lat, lon
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('published')
+    ap.add_argument('corrected_mask')
+    ap.add_argument('output')
+    ap.add_argument('--dry-run', action='store_true')
+    a = ap.parse_args()
+
+    fields, lat, lon = read_all(a.published)
+    names = [sn for sn, _ in fields]
+    if 'lsm' not in names:
+        sys.exit('  no lsm in the published file')
+    k_lsm = names.index('lsm')
+    pub = np.array(fields[k_lsm][1], copy=True)
+
+    fixed = np.load(a.corrected_mask)
+    if len(fixed) != len(pub):
+        sys.exit(f'  mask has {len(fixed)} cells, file has {len(pub)}')
+
+    lon180 = np.where(lon > 180, lon - 360, lon)
+    band = np.abs(np.abs(lon180) - 180) < DATELINE_HALFWIDTH_DEG
+    wrong = band & (np.round(pub) != np.round(fixed))
+    to_ocean = np.where(wrong & (fixed < 0.5))[0]
+    to_land = np.where(wrong & (fixed >= 0.5))[0]
+
+    print(f'  {a.published}')
+    print(f'    cells in the dateline band          : {int(band.sum())}')
+    print(f'    of those, land in the published file: {int((pub[band] >= 0.5).sum())}')
+    print(f'    of those, land in the corrected mask: {int((fixed[band] >= 0.5).sum())}')
+    print(f'    to repair: {len(to_ocean)} -> ocean, {len(to_land)} -> land')
+    outside = int(((np.round(pub) != np.round(fixed)) & ~band).sum())
+    print(f'    left alone, outside the band        : {outside} '
+          f'(coastline drift, not this defect)')
+    if len(to_ocean) == 0 and len(to_land) == 0:
+        print('    nothing to do')
+        return
+
+    new = [np.array(v, copy=True) for _, v in fields]
+    new[k_lsm][to_ocean] = 0.0
+    new[k_lsm][to_land] = 1.0
+
+    # Rebuild each repaired cell from the nearest stable neighbour of its NEW
+    # type. Unit vectors on the sphere: nearest = largest dot product.
+    rlat, rlon = np.deg2rad(np.asarray(lat, float)), np.deg2rad(np.asarray(lon, float))
+    vx, vy, vz = (np.cos(rlat) * np.cos(rlon), np.cos(rlat) * np.sin(rlon),
+                  np.sin(rlat))
+    npts = len(pub)
+    repaired = np.zeros(npts, bool)
+    repaired[to_ocean] = True
+    repaired[to_land] = True
+    is_land = new[k_lsm] >= 0.5
+    donor_ocean = np.where(~is_land & ~repaired)[0]
+    donor_land = np.where(is_land & ~repaired)[0]
+
+    def seed(cells, donors, label):
+        if len(cells) and donors.size == 0:
+            sys.exit(f'  no stable {label} donors available')
+        for i in cells:
+            dots = vx[donors] * vx[i] + vy[donors] * vy[i] + vz[donors] * vz[i]
+            j = int(donors[int(np.argmax(dots))])
+            for f in range(len(new)):
+                if f == k_lsm or len(new[f]) != npts:
+                    continue
+                new[f][i] = new[f][j]
+
+    seed(to_ocean, donor_ocean, 'ocean')
+    seed(to_land, donor_land, 'land')
+
+    # ---------------------------------------------------------------- verify
+    touched = set(to_ocean.tolist()) | set(to_land.tolist())
+    bad = []
+    for k, name in enumerate(names):
+        ch = np.where(fields[k][1] != new[k])[0]
+        stray = [int(c) for c in ch if int(c) not in touched]
+        if stray:
+            bad.append(f'{name}: {len(stray)} cells changed outside the repair set')
+    nb = int((new[k_lsm][band] >= 0.5).sum())
+    print(f'    after: dateline band land = {nb}/{int(band.sum())} '
+          f'({100 * nb / band.sum():.0f} %)')
+    print(f'    land total {int((pub >= 0.5).sum())} -> {int((new[k_lsm] >= 0.5).sum())}')
+    print(f'    changes confined to the repair set: {not bad}')
+    if bad:
+        for b in bad:
+            print(f'      FAIL: {b}')
+        sys.exit('  verification failed; nothing written')
+
+    if a.dry_run:
+        print('    --dry-run, nothing written')
+        return
+
+    out = Path(a.output)
+    tmp = out.with_suffix(out.suffix + '.tmp')
+    with open(a.published, 'rb') as fin, open(tmp, 'wb') as fout:
+        k = 0
+        while True:
+            gid = eccodes.codes_grib_new_from_file(fin)
+            if gid is None:
+                break
+            try:
+                eccodes.codes_set_values(gid, new[k])
+                eccodes.codes_write(gid, fout)
+            finally:
+                eccodes.codes_release(gid)
+            k += 1
+    tmp.replace(out)
+    check, _, _ = read_all(out)
+    assert [sn for sn, _ in check] == names, 'message order changed'
+    cl_lsm = check[k_lsm][1]
+    print(f'    wrote {out}  (read back: land {int((cl_lsm >= 0.5).sum())}, '
+          f'dateline {int((cl_lsm[band] >= 0.5).sum())}/{int(band.sum())})')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/repair_lake_cover.py
+++ b/tools/repair_lake_cover.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Put the lake fields back into a published ICMGG, in place.
+
+WHY NOT JUST RE-RUN OCP-TOOL.  Regenerating an ICMGG from mesh.nc recomputes
+the land-sea mask, and the published files do not all date from the current
+meshes -- for DARS2 a regeneration moved the coastline by 1989 cells.  Moving a
+coastline is a far larger change than the defect being fixed, and it would also
+sweep in every unrelated ocp-tool change since the file was published.  This is
+the same argument that produced the _v2 files by repair rather than by
+regeneration, and it applies unchanged here.
+
+WHAT THIS DOES INSTEAD.  It never recomputes the mask.  The flipped cells are
+recovered by comparing the published file's ``lsm`` against the pristine
+input's -- a cell that was ocean and is now land is a cell the flip touched --
+so no mesh, no polygon test, and zero coastline risk by construction.  At those
+cells and nowhere else it restores the pristine ``cl``, ``dl`` and FLake
+prognostics, which ``fill_flipped_from_nearest_neighbour`` had overwritten from
+the nearest dry land neighbour.
+
+WHAT IS DELIBERATELY NOT TOUCHED.  ``lsm`` and ``slt``.  The mask must stay
+byte-identical for the file to be a drop-in, and the soil repair already in the
+_v2 files is a separate, independently validated change that this must not
+disturb.  Because ``slt`` is unchanged, the derived LPJ-GUESS soil file
+(``grib_copy -w shortName=slt``) is unchanged too and does NOT need
+republishing -- only the ICMGG does.
+
+The result is verified before it is written: every field other than the lake
+set must come out bit-identical, and the lake set must differ only at flipped
+cells.  A failure of either check aborts rather than producing a file.
+
+Usage:
+    repair_lake_cover.py PRISTINE PUBLISHED OUTPUT [--dry-run]
+
+    PRISTINE   the untouched ICMGG the published file was built from
+    PUBLISHED  the _v2 file to repair
+    OUTPUT     the file to write (conventionally _v3)
+"""
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import eccodes
+
+# FLake integrates MIN(50, MAX(2, dl)); flakeene_mod.F90:211-212,238 and
+# surftstp_ctl_mod.F90:882. Writing a depth outside that band claims a
+# behaviour the model will not produce.
+FLAKE_DEPTH_MIN_M, FLAKE_DEPTH_MAX_M = 2.0, 50.0
+
+# The fields the nearest-neighbour fill destroys and this restores.
+LAKE_FIELDS = ('cl', 'dl', 'lmlt', 'lblt', 'lmld', 'lict', 'licd', 'ltlt',
+               'lshf')
+# Must come through untouched: the mask so the file stays a drop-in, the soil
+# type so the _v2 repair is preserved.
+PROTECTED = ('lsm', 'slt')
+
+
+def read_all(path):
+    """[(shortName, values)] in file order, plus the coordinates."""
+    out, lon = [], None
+    with open(path, 'rb') as f:
+        while True:
+            gid = eccodes.codes_grib_new_from_file(f)
+            if gid is None:
+                break
+            try:
+                sn = eccodes.codes_get(gid, 'shortName')
+                out.append((sn, eccodes.codes_get_values(gid)))
+                if sn == 'lsm' and lon is None:
+                    lon = eccodes.codes_get_array(gid, 'longitudes')
+            finally:
+                eccodes.codes_release(gid)
+    return out, lon
+
+
+def first(fields, name):
+    for sn, v in fields:
+        if sn == name:
+            return v
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('pristine')
+    ap.add_argument('published')
+    ap.add_argument('output')
+    ap.add_argument('--dry-run', action='store_true',
+                    help='report what would change and write nothing')
+    a = ap.parse_args()
+
+    pristine, _ = read_all(a.pristine)
+    published, lon = read_all(a.published)
+    print(f'  pristine  {a.pristine}  ({len(pristine)} messages)')
+    print(f'  published {a.published} ({len(published)} messages)')
+
+    p_lsm, q_lsm = first(pristine, 'lsm'), first(published, 'lsm')
+    if p_lsm is None or q_lsm is None:
+        sys.exit('  no lsm in one of the files')
+    if len(p_lsm) != len(q_lsm):
+        sys.exit(f'  grid mismatch: {len(p_lsm)} vs {len(q_lsm)} cells')
+
+    # The flip, recovered from the two masks. No mesh is read.
+    flipped = np.where((p_lsm < 0.5) & (q_lsm >= 0.5))[0]
+    print(f'\n  cells flipped ocean -> land: {len(flipped)}')
+    if len(flipped) == 0:
+        sys.exit('  nothing was flipped; this file needs no lake repair')
+
+    pmap = {}
+    for i, (sn, v) in enumerate(pristine):
+        pmap.setdefault(sn, v)
+
+    # Build the repaired values.
+    new = [np.array(v, copy=True) for _, v in published]
+    names = [sn for sn, _ in published]
+    touched = {}
+    for name in LAKE_FIELDS:
+        if name not in names or name not in pmap:
+            print(f'    {name:6s} absent, skipped')
+            continue
+        k = names.index(name)
+        src = pmap[name]
+        if len(src) != len(new[k]):
+            sys.exit(f'  {name}: length mismatch between the two files')
+        before = np.array(new[k], copy=True)
+        new[k][flipped] = src[flipped]
+        if name == 'dl':
+            new[k][flipped] = np.clip(new[k][flipped],
+                                      FLAKE_DEPTH_MIN_M, FLAKE_DEPTH_MAX_M)
+        n = int((before != new[k]).sum())
+        touched[name] = n
+        print(f'    {name:6s} restored at {n:5d} cells')
+
+    cl = first(published, 'cl')
+    print(f'\n  cl at the flipped cells: '
+          f'{cl[flipped].mean():.4f} -> {new[names.index("cl")][flipped].mean():.4f}'
+          f'   (majority-lake cells: '
+          f'{int((new[names.index("cl")][flipped] >= 0.5).sum())})')
+
+    # ---------------------------------------------------------------- verify
+    print('\n  VERIFICATION')
+    bad = []
+    for k, name in enumerate(names):
+        changed = np.where(published[k][1] != new[k])[0]
+        if name in PROTECTED and changed.size:
+            bad.append(f'{name} changed at {changed.size} cells (must not)')
+        elif name not in LAKE_FIELDS and changed.size:
+            bad.append(f'{name} changed at {changed.size} cells (not a lake field)')
+        elif changed.size and not np.isin(changed, flipped).all():
+            outside = int((~np.isin(changed, flipped)).sum())
+            bad.append(f'{name} changed at {outside} cells outside the flip')
+    for name in PROTECTED:
+        if name in names:
+            k = names.index(name)
+            ok = np.array_equal(published[k][1], new[k])
+            print(f'    {name:6s} bit-identical to the published file: {ok}')
+    print(f'    changes confined to the {len(flipped)} flipped cells: '
+          f'{not bad}')
+    if bad:
+        for b in bad:
+            print(f'      FAIL: {b}')
+        sys.exit('\n  verification failed; nothing written')
+
+    if a.dry_run:
+        print('\n  --dry-run, nothing written')
+        return
+
+    # ------------------------------------------------------------ write out
+    # Copy the published file and overwrite values message by message, so every
+    # GRIB header, packing choice and message order is inherited exactly.
+    out = Path(a.output)
+    shutil.copy2(a.published, out)
+    tmp = out.with_suffix(out.suffix + '.tmp')
+    with open(a.published, 'rb') as fin, open(tmp, 'wb') as fout:
+        k = 0
+        while True:
+            gid = eccodes.codes_grib_new_from_file(fin)
+            if gid is None:
+                break
+            try:
+                if names[k] in touched:
+                    eccodes.codes_set_values(gid, new[k])
+                eccodes.codes_write(gid, fout)
+            finally:
+                eccodes.codes_release(gid)
+            k += 1
+    tmp.replace(out)
+    print(f'\n  wrote {out}')
+
+    # Read it back: the file on disk is the thing that matters, not the arrays.
+    check, _ = read_all(out)
+    cnames = [sn for sn, _ in check]
+    assert cnames == names, 'message order changed'
+    for k, name in enumerate(names):
+        if name in PROTECTED:
+            assert np.array_equal(check[k][1], published[k][1]), \
+                f'{name} not preserved on disk'
+    ncl = first(check, 'cl')
+    print(f'  read back: cl >= 0.5 at {int((ncl >= 0.5).sum())} cells '
+          f'(published had {int((cl >= 0.5).sum())})')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Two silent surface-field defects, found while auditing what the land-sea flip does to a grid box.

## 1. The flip destroys lake cover

`fill_flipped_from_nearest_neighbour` rebuilds every flipped cell from the nearest **land** neighbour, and `cl` is just another surface field to it — so a cell the input called a lake inherits a dry neighbour's cover.

TCO95/CORE3: of 319 cells flipped to land, **70 had `cl >= 0.5`** in the input, including the whole Caspian (27/27) and Great Lakes (17/17). After the flip, none do. TCO319 loses ~1000 per file.

`lakes.restore_flipped_lakes` (default off) restores the pristine `cl`, `dl` and FLake prognostics at every flipped cell. No threshold is needed: `cl` is the lake share of a box, capped by the water share (`cl <= 1 - lsm` at all 40 320 cells), so the input has already classified each cell — genuine lakes get their mean 0.799, coastal cells whose water is sea get their 0.019. `dl` is clipped to `[2, 50]` m, the band FLake actually integrates (`flakeene_mod.F90:238`).

The guard is on **field presence, not cycle number**: CY43R3 was expected to lack the FLake fields but measurably carries all nine, so a cycle gate would have disabled the feature where it works.

This does not touch `lsm`, so the OASIS masks are unaffected, and it does not remove cells from the LPJ-GUESS gridlist — the soil repair is still required and not substitutable (overlap: 67 of 314 cells).

## 2. A wall of false land down the dateline

Pass 2 shifts dateline triangles to 0–360, but **polar-cap triangles stay wide** — at the pole longitude carries no information, and CORE2 has one spanning 237° after the shift. It overlaps most of the domain, so the trapezoid map cannot be built, `Triangulation is invalid` was raised, a bare `except` warned and continued, and every point the pass would have classified kept the `land` default:

```
TCO95/CORE2, land within 0.5 deg of lon 180:  192/192 = 100%   (input says 9%)
```

A pole-to-pole seam, accounting for 175 of the 396 ocean-to-land flips.

Fix: drop triangles still spanning >180° after the shift, and **raise** instead of warning when the pass fails.

```
CORE2  192/192 -> 17/192 = 9%, matching its input;  land 11576 -> 11400
CORE3  bit-identical, 0 cells changed
```

CORE3 has such a triangle too and merely happened to survive, so this was never CORE2-specific.

## Also

`tools/repair_lake_cover.py` — in-place repair of the published `_v2` ICMGGs that never recomputes a coastline; verifies `lsm` and `slt` stay bit-identical and aborts rather than writing if not.

The last commit fixes flake8 `F821` (mine) and `F723` (pre-existing on master, so the syntax gate cannot pass without it).

## Testing

5 new tests driven by the real TCO95 ICMGG, including the `cl <= 1 - lsm` convention the restore depends on. Full suite 55 passed; CORE3 mask regression 0 cells changed.
