### PR TITLE
Restore the lakes on a dynamic-mesh regeneration

### DIFF
--- a/ocp_tool/dynamic_regen.py
+++ b/ocp_tool/dynamic_regen.py
@@ -58,6 +58,13 @@ def _build_config(template, mesh_dir, grid_name, ocp_tool_dir, generate_rmp,
     # directory every cycle and are referenced by exact name from esm_tools, so
     # they carry no risk of overwriting a pool file.
     raw["options"]["output_suffix"] = ""
+    # Restore the lake fields, unless the template has already decided. A static
+    # regeneration flips a cell once and the option is off by default there, but
+    # here the coastline moves every cycle, so leaving it off drops the lakes
+    # again on every leg. Measured on the TCO95 cavity submesh: all 70 majority
+    # lake cells, the Caspian and the Great Lakes among them, come out with no
+    # lake cover at all.
+    raw.setdefault("lakes", {}).setdefault("restore_flipped_lakes", True)
     # Pin root_dir so the input/ dirs resolve regardless of where we write the
     # generated config.
     raw.setdefault("paths", {})["root_dir"] = str(Path(ocp_tool_dir).resolve())


### PR DESCRIPTION
The lake restore from #58 is off by default, which is right for a static regeneration: it changes published files, so it has to be asked for. The dynamic path is the opposite case. There the coastline moves with the ice sheet and the mask is rebuilt every cycle, so the flip destroys the lake fields again on every leg and nobody is there to ask.

Measured on the TCO95 cavity submesh, both the pool chunk-1 ICMGG and the file `couple_in` regenerated for ismtest36 carry `cl >= 0.5` at zero cells, against 70 in the pristine input. The Caspian and the Great Lakes are among them, so FLake had nothing to integrate anywhere, on every `-is` run so far.

Set through `setdefault`, so a template that has already decided still wins.
